### PR TITLE
ci: labeler workflow uses fork's own labeler.yml, not upstream

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
-      with:
-        repository: "ggml-org/llama.cpp"
     - uses: actions/labeler@v6
       with:
         configuration-path: '.github/labeler.yml'


### PR DESCRIPTION
The labeler workflow hard-codes `repository: ggml-org/llama.cpp` on its checkout step, so it always reads upstream's `labeler.yml`. Upstream uses v5 `all:` composition syntax which `actions/labeler@v6` rejects:

    Error: Unknown config options were under "changed-files": all

Every PR to this fork has been failing the labeler check since the action was bumped to v6.

Drop the hard-coded `repository:` so the checkout uses its default (this fork's master), which already has correct v6 syntax. Decouples the fork from upstream's labeler.yml schema.