### PR TITLE
cuda: hopper wgmma path review follow-up (multi-GPU correctness + hardening)

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -205,7 +205,7 @@ option(GGML_LLAMAFILE                       "ggml: use LLAMAFILE"               
 option(GGML_CUDA                            "ggml: use CUDA"                                  OFF)
 option(GGML_MUSA                            "ggml: use MUSA"                                  OFF)
 option(GGML_CUDA_FORCE_MMQ                  "ggml: use mmq kernels instead of cuBLAS"         OFF)
-option(GGML_CUDA_HOPPER_Q1                  "ggml: opt-in sm_90a wgmma path for Q1_0 prefill" OFF)
+option(GGML_CUDA_HOPPER_Q1                  "ggml: opt-in sm_90a wgmma path for Q1_0/Q2_0 prefill" OFF)
 set   (GGML_CUDA_CUTLASS_DIR "" CACHE PATH    "ggml: CUTLASS checkout root for GGML_CUDA_HOPPER_Q1")
 option(GGML_CUDA_FORCE_CUBLAS               "ggml: always use cuBLAS instead of mmq kernels"  OFF)
 set   (GGML_CUDA_PEER_MAX_BATCH_SIZE "128" CACHE STRING

--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -139,14 +139,15 @@ if (CUDAToolkit_FOUND)
     endif()
 
     if (GGML_CUDA_HOPPER_Q1)
-        # opt-in Hopper (sm_90a) wgmma path for Q1_0 prefill; needs CUTLASS headers (CuTe)
+        # opt-in Hopper (sm_90a) wgmma path for Q1_0/Q2_0 prefill; needs CUTLASS headers (CuTe)
         if (NOT GGML_CUDA_CUTLASS_DIR)
             message(FATAL_ERROR "GGML_CUDA_HOPPER_Q1 requires GGML_CUDA_CUTLASS_DIR (CUTLASS checkout root)")
         endif()
-        add_compile_definitions(GGML_USE_HOPPER_Q1)
-        include_directories(${GGML_CUDA_CUTLASS_DIR}/include ${GGML_CUDA_CUTLASS_DIR}/tools/util/include)
-        list(APPEND CMAKE_CUDA_FLAGS " --expt-relaxed-constexpr")
-        string(REPLACE ";" " " CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+        target_compile_definitions(ggml-cuda PRIVATE GGML_USE_HOPPER_Q1)
+        target_include_directories(ggml-cuda PRIVATE
+            ${GGML_CUDA_CUTLASS_DIR}/include
+            ${GGML_CUDA_CUTLASS_DIR}/tools/util/include)
+        target_compile_options(ggml-cuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
     endif()
 
     if (GGML_CUDA_FORCE_CUBLAS)

--- a/ggml/src/ggml-cuda/mmq-hopper-q1.cu
+++ b/ggml/src/ggml-cuda/mmq-hopper-q1.cu
@@ -4,12 +4,14 @@
 // flagged for KLD validation). Dispatched only when M,N,K % 128 == 0 and cc >= 900; otherwise the
 // caller falls through to the standard MMQ path.
 #include "common.cuh"
-#include <unordered_map>
+
 #include <mutex>
+#include <unordered_map>
 
 #if defined(GGML_USE_HOPPER_Q1)  // built only when CUTLASS include dir is provided
-#include <cuda_pipeline.h>
-#include <cute/tensor.hpp>
+#    include <cuda_pipeline.h>
+
+#    include <cute/tensor.hpp>
 using namespace cute;
 
 namespace hopper_q1 {
@@ -19,402 +21,489 @@ using MmaAtom = GMMA::MMA_64x64x32_S32S8S8_SS_TN;
 
 // fp32 -> int8 with per-128 absmax scale. Warp-per-group: 32 lanes x 4 floats (float4 loads),
 // shuffle reduction, vectorized 4x-int8 stores. 8 groups per 256-thread block.
-__global__ void quant_act_per128(const float* __restrict__ x, int8_t* __restrict__ q, float* __restrict__ d,
-                                 int M, int K) {
-  const int ngroups = M * (K / 128);
-  const int g = blockIdx.x * 8 + threadIdx.x / 32;  // group = (m, kc)
-  if (g >= ngroups) return;
-  const int lane = threadIdx.x % 32;
-  const int m = g / (K / 128), kc = g % (K / 128);
-  const float4* xs = reinterpret_cast<const float4*>(x + (size_t)m * K + kc * 128) + lane;
-  float4 v = *xs;
-  float amax = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)), fmaxf(fabsf(v.z), fabsf(v.w)));
-#pragma unroll
-  for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
-  const float scale = amax / 127.0f;
-  const float inv = scale > 0.f ? 1.0f / scale : 0.f;
-  // scale maps |x|<=amax to <=127, so this cannot overflow in exact arithmetic;
-  // clamp anyway to be robust to fp rounding at the boundary.
-  auto q8 = [] (float f) -> signed char {
-    long r = lrintf(f);
-    return (signed char)(r < -127 ? -127 : (r > 127 ? 127 : r));
-  };
-  char4 out = make_char4(q8(v.x * inv), q8(v.y * inv), q8(v.z * inv), q8(v.w * inv));
-  *(reinterpret_cast<char4*>(q + (size_t)m * K + kc * 128) + lane) = out;
-  if (lane == 0) d[(size_t)m * (K / 128) + kc] = scale;
+__global__ void quant_act_per128(const float * __restrict__ x,
+                                 int8_t * __restrict__ q,
+                                 float * __restrict__ d,
+                                 int M,
+                                 int K) {
+    const int ngroups = M * (K / 128);
+    const int g       = blockIdx.x * 8 + threadIdx.x / 32;  // group = (m, kc)
+    if (g >= ngroups) {
+        return;
+    }
+    const int      lane = threadIdx.x % 32;
+    const int      m = g / (K / 128), kc = g % (K / 128);
+    const float4 * xs   = reinterpret_cast<const float4 *>(x + (size_t) m * K + kc * 128) + lane;
+    float4         v    = *xs;
+    float          amax = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)), fmaxf(fabsf(v.z), fabsf(v.w)));
+#    pragma unroll
+    for (int o = 16; o > 0; o >>= 1) {
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
+    }
+    const float scale = amax / 127.0f;
+    const float inv   = scale > 0.f ? 1.0f / scale : 0.f;
+    // scale maps |x|<=amax to <=127, so this cannot overflow in exact arithmetic;
+    // clamp anyway to be robust to fp rounding at the boundary.
+    auto        q8    = [](float f) -> signed char {
+        long r = lrintf(f);
+        return (signed char) (r < -127 ? -127 : (r > 127 ? 127 : r));
+    };
+    char4 out = make_char4(q8(v.x * inv), q8(v.y * inv), q8(v.z * inv), q8(v.w * inv));
+    *(reinterpret_cast<char4 *>(q + (size_t) m * K + kc * 128) + lane) = out;
+    if (lane == 0) {
+        d[(size_t) m * (K / 128) + kc] = scale;
+    }
 }
-
 
 // one-time repack: interleaved block_q1_0 (18 B blocks) -> dense bit words + fp32 scales.
 // Weights are static; runs once per tensor, then every GEMM reads coalesced dense arrays.
-__global__ void repack_q1_dense(const block_q1_0* __restrict__ W, unsigned* __restrict__ bits,
-                                float* __restrict__ dw, long nblocks_total) {
-  long b = (long)blockIdx.x * blockDim.x + threadIdx.x;
-  if (b >= nblocks_total) return;
-  const uint16_t* u16 = reinterpret_cast<const uint16_t*>(W + b);  // [0]=d, [1..8]=bit halves
-  dw[b] = __half2float(*reinterpret_cast<const __half*>(W + b));
-#pragma unroll
-  for (int w = 0; w < 4; ++w)
-    bits[b * 4 + w] = (unsigned)u16[1 + 2 * w] | ((unsigned)u16[2 + 2 * w] << 16);
+__global__ void repack_q1_dense(const block_q1_0 * __restrict__ W,
+                                unsigned * __restrict__ bits,
+                                float * __restrict__ dw,
+                                long nblocks_total) {
+    long b = (long) blockIdx.x * blockDim.x + threadIdx.x;
+    if (b >= nblocks_total) {
+        return;
+    }
+    const uint16_t * u16 = reinterpret_cast<const uint16_t *>(W + b);  // [0]=d, [1..8]=bit halves
+    dw[b]                = __half2float(*reinterpret_cast<const __half *>(W + b));
+#    pragma unroll
+    for (int w = 0; w < 4; ++w) {
+        bits[b * 4 + w] = (unsigned) u16[1 + 2 * w] | ((unsigned) u16[2 + 2 * w] << 16);
+    }
 }
 
-__global__ void repack_q2_dense(const block_q2_0* __restrict__ W, unsigned* __restrict__ bits,
-                                float* __restrict__ dw, long nblocks_total) {
-  long b = (long)blockIdx.x * blockDim.x + threadIdx.x;
-  if (b >= nblocks_total) return;
-  const uint16_t* u16 = reinterpret_cast<const uint16_t*>(W + b);  // [0]=d, [1..16]=2-bit field halves
-  dw[b] = __half2float(*reinterpret_cast<const __half*>(W + b));
-#pragma unroll
-  for (int w = 0; w < 8; ++w)
-    bits[b * 8 + w] = (unsigned)u16[1 + 2 * w] | ((unsigned)u16[2 + 2 * w] << 16);
+__global__ void repack_q2_dense(const block_q2_0 * __restrict__ W,
+                                unsigned * __restrict__ bits,
+                                float * __restrict__ dw,
+                                long nblocks_total) {
+    long b = (long) blockIdx.x * blockDim.x + threadIdx.x;
+    if (b >= nblocks_total) {
+        return;
+    }
+    const uint16_t * u16 = reinterpret_cast<const uint16_t *>(W + b);  // [0]=d, [1..16]=2-bit field halves
+    dw[b]                = __half2float(*reinterpret_cast<const __half *>(W + b));
+#    pragma unroll
+    for (int w = 0; w < 8; ++w) {
+        bits[b * 8 + w] = (unsigned) u16[1 + 2 * w] | ((unsigned) u16[2 + 2 * w] << 16);
+    }
 }
 
-struct DenseW { unsigned* bits; float* dw; };
+struct DenseW {
+    unsigned * bits;
+    float *    dw;
+};
+
 // Cache key: the weight pointer alone is ambiguous across devices and reshaped views,
 // so key on (device, wdata, N, K, wbits). Weights are static for the process lifetime;
 // the repacked buffers are freed at exit by the driver.
 // wbits = 1 (Q1_0 sign bits) or 2 (Q2_0 (q-1) fields); words per 128-block = 4*wbits.
 struct DenseKey {
-  int device; const void* wdata; long N; long K; int wbits;
-  bool operator==(const DenseKey& o) const {
-    return device == o.device && wdata == o.wdata && N == o.N && K == o.K && wbits == o.wbits;
-  }
+    int          device;
+    const void * wdata;
+    long         N;
+    long         K;
+    int          wbits;
+
+    bool operator==(const DenseKey & o) const {
+        return device == o.device && wdata == o.wdata && N == o.N && K == o.K && wbits == o.wbits;
+    }
 };
+
 struct DenseKeyHash {
-  size_t operator()(const DenseKey& k) const {
-    size_t h = std::hash<const void*>()(k.wdata);
-    h ^= std::hash<long>()(k.N) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-    h ^= std::hash<long>()(k.K) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-    h ^= std::hash<int>()((k.device << 4) | k.wbits) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-    return h;
-  }
+    size_t operator()(const DenseKey & k) const {
+        size_t h = std::hash<const void *>()(k.wdata);
+        h ^= std::hash<long>()(k.N) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        h ^= std::hash<long>()(k.K) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        h ^= std::hash<int>()((k.device << 4) | k.wbits) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        return h;
+    }
 };
-static DenseW get_dense_w(const void* wdata, long N, long K, int wbits, int device, cudaStream_t stream) {
-  static std::unordered_map<DenseKey, DenseW, DenseKeyHash> cache;
-  static std::mutex cache_mutex;  // ggml may dispatch from one host thread per device concurrently
-  const DenseKey key{device, wdata, N, K, wbits};
 
-  std::lock_guard<std::mutex> lock(cache_mutex);
-  auto it = cache.find(key);
-  if (it != cache.end()) return it->second;
+static DenseW get_dense_w(const void * wdata, long N, long K, int wbits, int device, cudaStream_t stream) {
+    static std::unordered_map<DenseKey, DenseW, DenseKeyHash> cache;
+    static std::mutex cache_mutex;  // ggml may dispatch from one host thread per device concurrently
+    const DenseKey    key{ device, wdata, N, K, wbits };
 
-  DenseW d{};
-  const long nb = N * (K / 128);
-  CUDA_CHECK(cudaMalloc(&d.bits, nb * 16 * wbits));  // 4*wbits words/block, 4 B/word
-  CUDA_CHECK(cudaMalloc(&d.dw, nb * sizeof(float)));
-  if (wbits == 1) {
-    repack_q1_dense<<<(unsigned)((nb + 255) / 256), 256, 0, stream>>>((const block_q1_0*)wdata, d.bits, d.dw, nb);
-  } else {
-    repack_q2_dense<<<(unsigned)((nb + 255) / 256), 256, 0, stream>>>((const block_q2_0*)wdata, d.bits, d.dw, nb);
-  }
-  // Publish only after repack is observably complete. A consumer GEMM may run on a
-  // different stream than the one used here, which would otherwise have no ordering
-  // dependency on the repack kernel and could read uninitialized dense buffers. The
-  // sync is one-time per (tensor,device); subsequent calls hit the cache.
-  CUDA_CHECK(cudaStreamSynchronize(stream));
-  cache.emplace(key, d);
-  return d;
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    auto                        it = cache.find(key);
+    if (it != cache.end()) {
+        return it->second;
+    }
+
+    DenseW     d{};
+    const long nb = N * (K / 128);
+    CUDA_CHECK(cudaMalloc(&d.bits, nb * 16 * wbits));  // 4*wbits words/block, 4 B/word
+    CUDA_CHECK(cudaMalloc(&d.dw, nb * sizeof(float)));
+    if (wbits == 1) {
+        repack_q1_dense<<<(unsigned) ((nb + 255) / 256), 256, 0, stream>>>((const block_q1_0 *) wdata, d.bits, d.dw,
+                                                                           nb);
+    } else {
+        repack_q2_dense<<<(unsigned) ((nb + 255) / 256), 256, 0, stream>>>((const block_q2_0 *) wdata, d.bits, d.dw,
+                                                                           nb);
+    }
+    // Publish only after repack is observably complete. A consumer GEMM may run on a
+    // different stream than the one used here, which would otherwise have no ordering
+    // dependency on the repack kernel and could read uninitialized dense buffers. The
+    // sync is one-time per (tensor,device); subsequent calls hit the cache.
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    cache.emplace(key, d);
+    return d;
 }
 
 template <int WBITS>
-__global__ __launch_bounds__(512) void lowbit_wgmma_ggml(const int8_t* __restrict__ Aq, const float* __restrict__ dA,
-                                                     const unsigned* __restrict__ Wbits, const float* __restrict__ Wd,
-                                                     float* __restrict__ C,
-                                                     int M, int N, int K) {
-  using SmemLayoutA = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bM>, Int<bK>>{}));
-  using SmemLayoutB = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bN>, Int<bK>>{}));
-  extern __shared__ __align__(128) int8_t smem[];
-  int8_t* sA[2] = {smem, smem + cosize_v<SmemLayoutA>};
-  int8_t* sB[2] = {smem + 2 * cosize_v<SmemLayoutA>, smem + 2 * cosize_v<SmemLayoutA> + cosize_v<SmemLayoutB>};
-  float* sDa[2];
-  float* sDw[2];
-  {
-    float* p = reinterpret_cast<float*>(smem + 2 * cosize_v<SmemLayoutA> + 2 * cosize_v<SmemLayoutB>);
-    sDa[0] = p; sDa[1] = p + bM; sDw[0] = p + 2 * bM; sDw[1] = p + 2 * bM + bN;
-  }
-  const int mblk = blockIdx.x, nblk = blockIdx.y;
-  const int wg = threadIdx.x / 128;
-  const int wgm = wg / 2, wgn = wg % 2;
-  TiledMMA mma = make_tiled_mma(MmaAtom{});
-  auto thr = mma.get_slice(threadIdx.x % 128);
-  Tensor acc_i32 = partition_fragment_C(mma, Shape<Int<64>, Int<64>>{});
-  auto acc_f32 = make_fragment_like<float>(acc_i32);
-  clear(acc_i32);
-  clear(acc_f32);
-  auto cAcc = thr.partition_C(make_identity_tensor(Shape<Int<64>, Int<64>>{}));
-
-  const int nblocks_row = K / 128;  // q1_0 blocks per weight row
-
-  auto load_stage = [&](int kc, int buf) {
-    Tensor tA = make_tensor(make_smem_ptr(sA[buf]), SmemLayoutA{});
-    Tensor tB = make_tensor(make_smem_ptr(sB[buf]), SmemLayoutB{});
-    // A: cp.async (global->SMEM, no register round-trip); latency hides under the B unpack below.
-    // A synchronous copy here costs ~1.8x end-to-end (exposed global latency per k-chunk).
-    constexpr int A_CHUNKS = bM * (bK / 16);
-    for (int i = threadIdx.x; i < A_CHUNKS; i += 512) {
-      int r = i / (bK / 16), c16 = (i % (bK / 16)) * 16;
-      __pipeline_memcpy_async(&tA(r, c16), Aq + (size_t)(mblk * bM + r) * K + kc * bK + c16, 16);
+__global__ __launch_bounds__(512) void lowbit_wgmma_ggml(const int8_t * __restrict__ Aq,
+                                                         const float * __restrict__ dA,
+                                                         const unsigned * __restrict__ Wbits,
+                                                         const float * __restrict__ Wd,
+                                                         float * __restrict__ C,
+                                                         int M,
+                                                         int N,
+                                                         int K) {
+    using SmemLayoutA = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bM>, Int<bK>>{}));
+    using SmemLayoutB = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bN>, Int<bK>>{}));
+    extern __shared__ __align__(128) int8_t smem[];
+    int8_t *                                sA[2] = { smem, smem + cosize_v<SmemLayoutA> };
+    int8_t * sB[2] = { smem + 2 * cosize_v<SmemLayoutA>, smem + 2 * cosize_v<SmemLayoutA> + cosize_v<SmemLayoutB> };
+    float *  sDa[2];
+    float *  sDw[2];
+    {
+        float * p = reinterpret_cast<float *>(smem + 2 * cosize_v<SmemLayoutA> + 2 * cosize_v<SmemLayoutB>);
+        sDa[0]    = p;
+        sDa[1]    = p + bM;
+        sDw[0]    = p + 2 * bM;
+        sDw[1]    = p + 2 * bM + bN;
     }
-    __pipeline_commit();
-    if constexpr (WBITS == 1) {
-      constexpr int B_WORDS = bN * (bK / 32);
-      for (int i = threadIdx.x; i < B_WORDS; i += 512) {
-        int r = i / (bK / 32), w = i % (bK / 32);
-        unsigned bits = Wbits[((size_t)(nblk * bN + r) * nblocks_row + kc) * 4 + w];
-        unsigned out[8];
-#pragma unroll
-        for (int nib = 0; nib < 8; ++nib) {
-          // branchless bit -> {+1,-1} byte expansion. NOT a __constant__ LUT: divergent indices
-          // serialize the constant cache (one address per warp per cycle) and real weight bits are
-          // high-entropy, costing ~1.7x end-to-end. Synthetic uniform test data hides this entirely.
-          unsigned nb = (bits >> (nib * 4)) & 0xF;
-          unsigned spread = (nb & 1u) | ((nb & 2u) << 7) | ((nb & 4u) << 14) | ((nb & 8u) << 21);
-          out[nib] = __vadd4(0xFFFFFFFFu, spread << 1);  // per-byte 0xFF + 2*bit, no cross-byte carry
-        }
-        *reinterpret_cast<int4*>(&tB(r, w * 32)) = make_int4(out[0], out[1], out[2], out[3]);
-        *reinterpret_cast<int4*>(&tB(r, w * 32 + 16)) = make_int4(out[4], out[5], out[6], out[7]);
-      }
-    } else {
-      // Q2_0: 16x 2-bit fields per word, value = q - 1 in {-1,0,+1,+2}; same no-LUT rule as above
-      constexpr int B_WORDS = bN * (bK / 16);
-      for (int i = threadIdx.x; i < B_WORDS; i += 512) {
-        int r = i / (bK / 16), w = i % (bK / 16);
-        unsigned bits = Wbits[((size_t)(nblk * bN + r) * nblocks_row + kc) * 8 + w];
-        unsigned out[4];
-#pragma unroll
-        for (int b8 = 0; b8 < 4; ++b8) {
-          unsigned f = (bits >> (b8 * 8)) & 0xFFu;
-          unsigned spread = (f & 0x03u) | ((f & 0x0Cu) << 6) | ((f & 0x30u) << 12) | ((f & 0xC0u) << 18);
-          out[b8] = __vsub4(spread, 0x01010101u);  // per-byte q - 1, no cross-byte borrow
-        }
-        *reinterpret_cast<int4*>(&tB(r, w * 16)) = make_int4(out[0], out[1], out[2], out[3]);
-      }
-    }
-    for (int i = threadIdx.x; i < bM; i += 512) sDa[buf][i] = dA[(size_t)(mblk * bM + i) * nblocks_row + kc];
-    for (int i = threadIdx.x; i < bN; i += 512) sDw[buf][i] = Wd[(size_t)(nblk * bN + i) * nblocks_row + kc];
-  };
-
-  const int nchunks = K / bK;
-  load_stage(0, 0);
-  for (int kc = 0; kc < nchunks; ++kc) {
-    int cur = kc & 1, nxt = cur ^ 1;
-    __pipeline_wait_prior(0);  // stage `cur` cp.async complete before it is published
-    __syncthreads();
-    using SmemLayoutH = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<64>, Int<bK>>{}));
-    Tensor tAh = make_tensor(make_smem_ptr(sA[cur] + wgm * (64 * bK)), SmemLayoutH{});
-    Tensor tBh = make_tensor(make_smem_ptr(sB[cur] + wgn * (64 * bK)), SmemLayoutH{});
-    Tensor tCsA = thr.partition_A(tAh);
-    Tensor tCsB = thr.partition_B(tBh);
-    warpgroup_fence_operand(acc_i32);
-    warpgroup_arrive();
-    gemm(mma, tCsA, tCsB, acc_i32);
-    warpgroup_commit_batch();
-    if (kc + 1 < nchunks) load_stage(kc + 1, nxt);
-    warpgroup_wait<0>();
-    warpgroup_fence_operand(acc_i32);
-    CUTE_UNROLL
-    for (int e = 0; e < size(acc_i32); ++e) {
-      int ml = get<0>(cAcc(e)) + wgm * 64;
-      int nl = get<1>(cAcc(e)) + wgn * 64;
-      acc_f32(e) += float(acc_i32(e)) * (sDa[cur][ml] * sDw[cur][nl]);
-    }
+    const int mblk = blockIdx.x, nblk = blockIdx.y;
+    const int wg  = threadIdx.x / 128;
+    const int wgm = wg / 2, wgn = wg % 2;
+    TiledMMA  mma     = make_tiled_mma(MmaAtom{});
+    auto      thr     = mma.get_slice(threadIdx.x % 128);
+    Tensor    acc_i32 = partition_fragment_C(mma, Shape<Int<64>, Int<64>>{});
+    auto      acc_f32 = make_fragment_like<float>(acc_i32);
     clear(acc_i32);
-  }
-  CUTE_UNROLL
-  for (int e = 0; e < size(acc_f32); ++e) {
-    int m = get<0>(cAcc(e)) + mblk * bM + wgm * 64;
-    int n = get<1>(cAcc(e)) + nblk * bN + wgn * 64;
-    C[(size_t)m * N + n] = acc_f32(e);
-  }
-}
+    clear(acc_f32);
+    auto cAcc = thr.partition_C(make_identity_tensor(Shape<Int<64>, Int<64>>{}));
 
+    const int nblocks_row = K / 128;  // q1_0 blocks per weight row
+
+    auto load_stage = [&](int kc, int buf) {
+        Tensor        tA       = make_tensor(make_smem_ptr(sA[buf]), SmemLayoutA{});
+        Tensor        tB       = make_tensor(make_smem_ptr(sB[buf]), SmemLayoutB{});
+        // A: cp.async (global->SMEM, no register round-trip); latency hides under the B unpack below.
+        // A synchronous copy here costs ~1.8x end-to-end (exposed global latency per k-chunk).
+        constexpr int A_CHUNKS = bM * (bK / 16);
+        for (int i = threadIdx.x; i < A_CHUNKS; i += 512) {
+            int r = i / (bK / 16), c16 = (i % (bK / 16)) * 16;
+            __pipeline_memcpy_async(&tA(r, c16), Aq + (size_t) (mblk * bM + r) * K + kc * bK + c16, 16);
+        }
+        __pipeline_commit();
+        if constexpr (WBITS == 1) {
+            constexpr int B_WORDS = bN * (bK / 32);
+            for (int i = threadIdx.x; i < B_WORDS; i += 512) {
+                int      r = i / (bK / 32), w = i % (bK / 32);
+                unsigned bits = Wbits[((size_t) (nblk * bN + r) * nblocks_row + kc) * 4 + w];
+                unsigned out[8];
+#    pragma unroll
+                for (int nib = 0; nib < 8; ++nib) {
+                    // branchless bit -> {+1,-1} byte expansion. NOT a __constant__ LUT: divergent indices
+                    // serialize the constant cache (one address per warp per cycle) and real weight bits are
+                    // high-entropy, costing ~1.7x end-to-end. Synthetic uniform test data hides this entirely.
+                    unsigned nb     = (bits >> (nib * 4)) & 0xF;
+                    unsigned spread = (nb & 1u) | ((nb & 2u) << 7) | ((nb & 4u) << 14) | ((nb & 8u) << 21);
+                    out[nib]        = __vadd4(0xFFFFFFFFu, spread << 1);  // per-byte 0xFF + 2*bit, no cross-byte carry
+                }
+                *reinterpret_cast<int4 *>(&tB(r, w * 32))      = make_int4(out[0], out[1], out[2], out[3]);
+                *reinterpret_cast<int4 *>(&tB(r, w * 32 + 16)) = make_int4(out[4], out[5], out[6], out[7]);
+            }
+        } else {
+            // Q2_0: 16x 2-bit fields per word, value = q - 1 in {-1,0,+1,+2}; same no-LUT rule as above
+            constexpr int B_WORDS = bN * (bK / 16);
+            for (int i = threadIdx.x; i < B_WORDS; i += 512) {
+                int      r = i / (bK / 16), w = i % (bK / 16);
+                unsigned bits = Wbits[((size_t) (nblk * bN + r) * nblocks_row + kc) * 8 + w];
+                unsigned out[4];
+#    pragma unroll
+                for (int b8 = 0; b8 < 4; ++b8) {
+                    unsigned f      = (bits >> (b8 * 8)) & 0xFFu;
+                    unsigned spread = (f & 0x03u) | ((f & 0x0Cu) << 6) | ((f & 0x30u) << 12) | ((f & 0xC0u) << 18);
+                    out[b8]         = __vsub4(spread, 0x01010101u);  // per-byte q - 1, no cross-byte borrow
+                }
+                *reinterpret_cast<int4 *>(&tB(r, w * 16)) = make_int4(out[0], out[1], out[2], out[3]);
+            }
+        }
+        for (int i = threadIdx.x; i < bM; i += 512)
+            sDa[buf][i] = dA[(size_t) (mblk * bM + i) * nblocks_row + kc];
+        for (int i = threadIdx.x; i < bN; i += 512)
+            sDw[buf][i] = Wd[(size_t) (nblk * bN + i) * nblocks_row + kc];
+    };
+
+    const int nchunks = K / bK;
+    load_stage(0, 0);
+    for (int kc = 0; kc < nchunks; ++kc) {
+        int cur = kc & 1, nxt = cur ^ 1;
+        __pipeline_wait_prior(0);  // stage `cur` cp.async complete before it is published
+        __syncthreads();
+        using SmemLayoutH = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<64>, Int<bK>>{}));
+        Tensor tAh        = make_tensor(make_smem_ptr(sA[cur] + wgm * (64 * bK)), SmemLayoutH{});
+        Tensor tBh        = make_tensor(make_smem_ptr(sB[cur] + wgn * (64 * bK)), SmemLayoutH{});
+        Tensor tCsA       = thr.partition_A(tAh);
+        Tensor tCsB       = thr.partition_B(tBh);
+        warpgroup_fence_operand(acc_i32);
+        warpgroup_arrive();
+        gemm(mma, tCsA, tCsB, acc_i32);
+        warpgroup_commit_batch();
+        if (kc + 1 < nchunks) {
+            load_stage(kc + 1, nxt);
+        }
+        warpgroup_wait<0>();
+        warpgroup_fence_operand(acc_i32);
+        CUTE_UNROLL
+        for (int e = 0; e < size(acc_i32); ++e) {
+            int ml = get<0>(cAcc(e)) + wgm * 64;
+            int nl = get<1>(cAcc(e)) + wgn * 64;
+            acc_f32(e) += float(acc_i32(e)) * (sDa[cur][ml] * sDw[cur][nl]);
+        }
+        clear(acc_i32);
+    }
+    CUTE_UNROLL
+    for (int e = 0; e < size(acc_f32); ++e) {
+        int m                 = get<0>(cAcc(e)) + mblk * bM + wgm * 64;
+        int n                 = get<1>(cAcc(e)) + nblk * bN + wgn * 64;
+        C[(size_t) m * N + n] = acc_f32(e);
+    }
+}
 
 // stream-K variant: persistent work-centric loop; scaled fp32 partials atomicAdd'd into pre-zeroed C
 template <int WBITS>
-__global__ __launch_bounds__(512) void lowbit_wgmma_ggml_sk(const int8_t* __restrict__ Aq, const float* __restrict__ dA,
-                                                        const unsigned* __restrict__ Wbits, const float* __restrict__ Wd,
-                                                     float* __restrict__ C,
-                                                        int M, int N, int K, int ntn, long total, int ncta) {
-  using SmemLayoutA = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bM>, Int<bK>>{}));
-  using SmemLayoutB = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bN>, Int<bK>>{}));
-  extern __shared__ __align__(128) int8_t smem[];
-  int8_t* sA[2] = {smem, smem + cosize_v<SmemLayoutA>};
-  int8_t* sB[2] = {smem + 2 * cosize_v<SmemLayoutA>, smem + 2 * cosize_v<SmemLayoutA> + cosize_v<SmemLayoutB>};
-  float* sDa[2]; float* sDw[2];
-  { float* p = reinterpret_cast<float*>(smem + 2 * cosize_v<SmemLayoutA> + 2 * cosize_v<SmemLayoutB>);
-    sDa[0]=p; sDa[1]=p+bM; sDw[0]=p+2*bM; sDw[1]=p+2*bM+bN; }
-  int mblk = 0, nblk = 0;
-  const int wg = threadIdx.x / 128; const int wgm = wg / 2, wgn = wg % 2;
-  TiledMMA mma = make_tiled_mma(MmaAtom{});
-  auto thr = mma.get_slice(threadIdx.x % 128);
-  Tensor acc_i32 = partition_fragment_C(mma, Shape<Int<64>, Int<64>>{});
-  auto acc_f32 = make_fragment_like<float>(acc_i32);
-  clear(acc_i32); clear(acc_f32);
-  auto cAcc = thr.partition_C(make_identity_tensor(Shape<Int<64>, Int<64>>{}));
-  const int nblocks_row = K / 128;
-  auto load_stage = [&](int kc, int buf) {
-    Tensor tA = make_tensor(make_smem_ptr(sA[buf]), SmemLayoutA{});
-    Tensor tB = make_tensor(make_smem_ptr(sB[buf]), SmemLayoutB{});
-    constexpr int A_CHUNKS = bM * (bK / 16);  // A via cp.async (see fixed-grid kernel note)
-    for (int i = threadIdx.x; i < A_CHUNKS; i += 512) {
-      int r = i / (bK / 16), c16 = (i % (bK / 16)) * 16;
-      __pipeline_memcpy_async(&tA(r, c16), Aq + (size_t)(mblk * bM + r) * K + kc * bK + c16, 16);
-    }
-    __pipeline_commit();
-    if constexpr (WBITS == 1) {
-      constexpr int B_WORDS = bN * (bK / 32);
-      for (int i = threadIdx.x; i < B_WORDS; i += 512) {
-        int r = i / (bK / 32), w = i % (bK / 32);
-        unsigned bits = Wbits[((size_t)(nblk * bN + r) * nblocks_row + kc) * 4 + w];
-        unsigned out[8];
-#pragma unroll
-        for (int nib = 0; nib < 8; ++nib) {
-          // branchless bit -> {+1,-1} byte expansion. NOT a __constant__ LUT: divergent indices
-          // serialize the constant cache (one address per warp per cycle) and real weight bits are
-          // high-entropy, costing ~1.7x end-to-end. Synthetic uniform test data hides this entirely.
-          unsigned nb = (bits >> (nib * 4)) & 0xF;
-          unsigned spread = (nb & 1u) | ((nb & 2u) << 7) | ((nb & 4u) << 14) | ((nb & 8u) << 21);
-          out[nib] = __vadd4(0xFFFFFFFFu, spread << 1);  // per-byte 0xFF + 2*bit, no cross-byte carry
-        }
-        *reinterpret_cast<int4*>(&tB(r, w * 32)) = make_int4(out[0], out[1], out[2], out[3]);
-        *reinterpret_cast<int4*>(&tB(r, w * 32 + 16)) = make_int4(out[4], out[5], out[6], out[7]);
-      }
-    } else {
-      // Q2_0: 16x 2-bit fields per word, value = q - 1 in {-1,0,+1,+2}; same no-LUT rule as above
-      constexpr int B_WORDS = bN * (bK / 16);
-      for (int i = threadIdx.x; i < B_WORDS; i += 512) {
-        int r = i / (bK / 16), w = i % (bK / 16);
-        unsigned bits = Wbits[((size_t)(nblk * bN + r) * nblocks_row + kc) * 8 + w];
-        unsigned out[4];
-#pragma unroll
-        for (int b8 = 0; b8 < 4; ++b8) {
-          unsigned f = (bits >> (b8 * 8)) & 0xFFu;
-          unsigned spread = (f & 0x03u) | ((f & 0x0Cu) << 6) | ((f & 0x30u) << 12) | ((f & 0xC0u) << 18);
-          out[b8] = __vsub4(spread, 0x01010101u);  // per-byte q - 1, no cross-byte borrow
-        }
-        *reinterpret_cast<int4*>(&tB(r, w * 16)) = make_int4(out[0], out[1], out[2], out[3]);
-      }
-    }
-    for (int i = threadIdx.x; i < bM; i += 512) sDa[buf][i] = dA[(size_t)(mblk * bM + i) * nblocks_row + kc];
-    for (int i = threadIdx.x; i < bN; i += 512) sDw[buf][i] = Wd[(size_t)(nblk * bN + i) * nblocks_row + kc];
-  };
-  const int nchunks = K / 128;
-  auto flush = [&](bool owned) {
-    CUTE_UNROLL
-    for (int e = 0; e < size(acc_f32); ++e) {
-      int m = get<0>(cAcc(e)) + mblk * bM + wgm * 64;
-      int n = get<1>(cAcc(e)) + nblk * bN + wgn * 64;
-      if (owned) C[(size_t)m * N + n] = acc_f32(e);          // whole tile in this CTA's span
-      else atomicAdd(&C[(size_t)m * N + n], acc_f32(e));      // split tile (C pre-zeroed)
-    }
-    clear(acc_f32);
-  };
-  auto tile_owned = [&](int tile, long lo, long hi) {
-    long first = (long)tile * nchunks, last = first + nchunks - 1;
-    return first >= lo && last < hi;
-  };
-  const int cta = blockIdx.x;
-  long u0 = (long)cta * total / ncta, u1 = (long)(cta + 1) * total / ncta;
-  int cur_tile = -1, buf = 0;
-  for (long u = u0; u < u1; ++u) {
-    int tile = (int)(u / nchunks), kc = (int)(u % nchunks);
-    if (tile != cur_tile) {
-      if (cur_tile >= 0) flush(tile_owned(cur_tile, u0, u1));
-      cur_tile = tile; mblk = tile / ntn; nblk = tile % ntn; buf = 0;
-      load_stage(kc, buf);
-    }
-    __pipeline_wait_prior(0);  // stage `buf` cp.async complete before it is published
-    __syncthreads();
+__global__ __launch_bounds__(512) void lowbit_wgmma_ggml_sk(const int8_t * __restrict__ Aq,
+                                                            const float * __restrict__ dA,
+                                                            const unsigned * __restrict__ Wbits,
+                                                            const float * __restrict__ Wd,
+                                                            float * __restrict__ C,
+                                                            int  M,
+                                                            int  N,
+                                                            int  K,
+                                                            int  ntn,
+                                                            long total,
+                                                            int  ncta) {
+    using SmemLayoutA = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bM>, Int<bK>>{}));
+    using SmemLayoutB = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<bN>, Int<bK>>{}));
+    extern __shared__ __align__(128) int8_t smem[];
+    int8_t *                                sA[2] = { smem, smem + cosize_v<SmemLayoutA> };
+    int8_t * sB[2] = { smem + 2 * cosize_v<SmemLayoutA>, smem + 2 * cosize_v<SmemLayoutA> + cosize_v<SmemLayoutB> };
+    float *  sDa[2];
+    float *  sDw[2];
     {
-      using SmemLayoutH = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<64>, Int<bK>>{}));
-      Tensor tAh = make_tensor(make_smem_ptr(sA[buf] + wgm * (64 * bK)), SmemLayoutH{});
-      Tensor tBh = make_tensor(make_smem_ptr(sB[buf] + wgn * (64 * bK)), SmemLayoutH{});
-      Tensor tCsA = thr.partition_A(tAh);
-      Tensor tCsB = thr.partition_B(tBh);
-      warpgroup_fence_operand(acc_i32);
-      warpgroup_arrive();
-      gemm(mma, tCsA, tCsB, acc_i32);
-      warpgroup_commit_batch();
+        float * p = reinterpret_cast<float *>(smem + 2 * cosize_v<SmemLayoutA> + 2 * cosize_v<SmemLayoutB>);
+        sDa[0]    = p;
+        sDa[1]    = p + bM;
+        sDw[0]    = p + 2 * bM;
+        sDw[1]    = p + 2 * bM + bN;
     }
-    bool next_same = (u + 1 < u1) && ((u + 1) / nchunks == tile);
-    if (next_same) load_stage(kc + 1, buf ^ 1);
-    warpgroup_wait<0>();
-    warpgroup_fence_operand(acc_i32);
-    CUTE_UNROLL
-    for (int e = 0; e < size(acc_i32); ++e) {
-      int ml = get<0>(cAcc(e)) + wgm * 64;
-      int nl = get<1>(cAcc(e)) + wgn * 64;
-      acc_f32(e) += float(acc_i32(e)) * (sDa[buf][ml] * sDw[buf][nl]);
-    }
+    int       mblk = 0, nblk = 0;
+    const int wg  = threadIdx.x / 128;
+    const int wgm = wg / 2, wgn = wg % 2;
+    TiledMMA  mma     = make_tiled_mma(MmaAtom{});
+    auto      thr     = mma.get_slice(threadIdx.x % 128);
+    Tensor    acc_i32 = partition_fragment_C(mma, Shape<Int<64>, Int<64>>{});
+    auto      acc_f32 = make_fragment_like<float>(acc_i32);
     clear(acc_i32);
-    if (next_same) buf ^= 1;
-    __syncthreads();
-  }
-  if (cur_tile >= 0) flush(tile_owned(cur_tile, u0, u1));
+    clear(acc_f32);
+    auto      cAcc        = thr.partition_C(make_identity_tensor(Shape<Int<64>, Int<64>>{}));
+    const int nblocks_row = K / 128;
+    auto      load_stage  = [&](int kc, int buf) {
+        Tensor        tA       = make_tensor(make_smem_ptr(sA[buf]), SmemLayoutA{});
+        Tensor        tB       = make_tensor(make_smem_ptr(sB[buf]), SmemLayoutB{});
+        constexpr int A_CHUNKS = bM * (bK / 16);  // A via cp.async (see fixed-grid kernel note)
+        for (int i = threadIdx.x; i < A_CHUNKS; i += 512) {
+            int r = i / (bK / 16), c16 = (i % (bK / 16)) * 16;
+            __pipeline_memcpy_async(&tA(r, c16), Aq + (size_t) (mblk * bM + r) * K + kc * bK + c16, 16);
+        }
+        __pipeline_commit();
+        if constexpr (WBITS == 1) {
+            constexpr int B_WORDS = bN * (bK / 32);
+            for (int i = threadIdx.x; i < B_WORDS; i += 512) {
+                int      r = i / (bK / 32), w = i % (bK / 32);
+                unsigned bits = Wbits[((size_t) (nblk * bN + r) * nblocks_row + kc) * 4 + w];
+                unsigned out[8];
+#    pragma unroll
+                for (int nib = 0; nib < 8; ++nib) {
+                    // branchless bit -> {+1,-1} byte expansion. NOT a __constant__ LUT: divergent indices
+                    // serialize the constant cache (one address per warp per cycle) and real weight bits are
+                    // high-entropy, costing ~1.7x end-to-end. Synthetic uniform test data hides this entirely.
+                    unsigned nb     = (bits >> (nib * 4)) & 0xF;
+                    unsigned spread = (nb & 1u) | ((nb & 2u) << 7) | ((nb & 4u) << 14) | ((nb & 8u) << 21);
+                    out[nib]        = __vadd4(0xFFFFFFFFu, spread << 1);  // per-byte 0xFF + 2*bit, no cross-byte carry
+                }
+                *reinterpret_cast<int4 *>(&tB(r, w * 32))      = make_int4(out[0], out[1], out[2], out[3]);
+                *reinterpret_cast<int4 *>(&tB(r, w * 32 + 16)) = make_int4(out[4], out[5], out[6], out[7]);
+            }
+        } else {
+            // Q2_0: 16x 2-bit fields per word, value = q - 1 in {-1,0,+1,+2}; same no-LUT rule as above
+            constexpr int B_WORDS = bN * (bK / 16);
+            for (int i = threadIdx.x; i < B_WORDS; i += 512) {
+                int      r = i / (bK / 16), w = i % (bK / 16);
+                unsigned bits = Wbits[((size_t) (nblk * bN + r) * nblocks_row + kc) * 8 + w];
+                unsigned out[4];
+#    pragma unroll
+                for (int b8 = 0; b8 < 4; ++b8) {
+                    unsigned f      = (bits >> (b8 * 8)) & 0xFFu;
+                    unsigned spread = (f & 0x03u) | ((f & 0x0Cu) << 6) | ((f & 0x30u) << 12) | ((f & 0xC0u) << 18);
+                    out[b8]         = __vsub4(spread, 0x01010101u);  // per-byte q - 1, no cross-byte borrow
+                }
+                *reinterpret_cast<int4 *>(&tB(r, w * 16)) = make_int4(out[0], out[1], out[2], out[3]);
+            }
+        }
+        for (int i = threadIdx.x; i < bM; i += 512)
+            sDa[buf][i] = dA[(size_t) (mblk * bM + i) * nblocks_row + kc];
+        for (int i = threadIdx.x; i < bN; i += 512)
+            sDw[buf][i] = Wd[(size_t) (nblk * bN + i) * nblocks_row + kc];
+    };
+    const int nchunks = K / 128;
+    auto      flush   = [&](bool owned) {
+        CUTE_UNROLL
+        for (int e = 0; e < size(acc_f32); ++e) {
+            int m = get<0>(cAcc(e)) + mblk * bM + wgm * 64;
+            int n = get<1>(cAcc(e)) + nblk * bN + wgn * 64;
+            if (owned) {
+                C[(size_t) m * N + n] = acc_f32(e);             // whole tile in this CTA's span
+            } else {
+                atomicAdd(&C[(size_t) m * N + n], acc_f32(e));  // split tile (C pre-zeroed)
+            }
+        }
+        clear(acc_f32);
+    };
+    auto tile_owned = [&](int tile, long lo, long hi) {
+        long first = (long) tile * nchunks, last = first + nchunks - 1;
+        return first >= lo && last < hi;
+    };
+    const int cta = blockIdx.x;
+    long      u0 = (long) cta * total / ncta, u1 = (long) (cta + 1) * total / ncta;
+    int       cur_tile = -1, buf = 0;
+    for (long u = u0; u < u1; ++u) {
+        int tile = (int) (u / nchunks), kc = (int) (u % nchunks);
+        if (tile != cur_tile) {
+            if (cur_tile >= 0) {
+                flush(tile_owned(cur_tile, u0, u1));
+            }
+            cur_tile = tile;
+            mblk     = tile / ntn;
+            nblk     = tile % ntn;
+            buf      = 0;
+            load_stage(kc, buf);
+        }
+        __pipeline_wait_prior(0);  // stage `buf` cp.async complete before it is published
+        __syncthreads();
+        {
+            using SmemLayoutH = decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<int8_t>{}, Shape<Int<64>, Int<bK>>{}));
+            Tensor tAh        = make_tensor(make_smem_ptr(sA[buf] + wgm * (64 * bK)), SmemLayoutH{});
+            Tensor tBh        = make_tensor(make_smem_ptr(sB[buf] + wgn * (64 * bK)), SmemLayoutH{});
+            Tensor tCsA       = thr.partition_A(tAh);
+            Tensor tCsB       = thr.partition_B(tBh);
+            warpgroup_fence_operand(acc_i32);
+            warpgroup_arrive();
+            gemm(mma, tCsA, tCsB, acc_i32);
+            warpgroup_commit_batch();
+        }
+        bool next_same = (u + 1 < u1) && ((u + 1) / nchunks == tile);
+        if (next_same) {
+            load_stage(kc + 1, buf ^ 1);
+        }
+        warpgroup_wait<0>();
+        warpgroup_fence_operand(acc_i32);
+        CUTE_UNROLL
+        for (int e = 0; e < size(acc_i32); ++e) {
+            int ml = get<0>(cAcc(e)) + wgm * 64;
+            int nl = get<1>(cAcc(e)) + wgn * 64;
+            acc_f32(e) += float(acc_i32(e)) * (sDa[buf][ml] * sDw[buf][nl]);
+        }
+        clear(acc_i32);
+        if (next_same) {
+            buf ^= 1;
+        }
+        __syncthreads();
+    }
+    if (cur_tile >= 0) {
+        flush(tile_owned(cur_tile, u0, u1));
+    }
 }
 
 }  // namespace hopper_q1
 #endif  // GGML_USE_HOPPER_Q1
 
 // returns false if the shape/arch is unsupported (caller falls through to standard MMQ)
-bool ggml_cuda_mul_mat_q1_hopper(ggml_backend_cuda_context& ctx, const ggml_tensor* src0, const ggml_tensor* src1,
-                                 ggml_tensor* dst) {
+bool ggml_cuda_mul_mat_q1_hopper(ggml_backend_cuda_context & ctx,
+                                 const ggml_tensor *         src0,
+                                 const ggml_tensor *         src1,
+                                 ggml_tensor *               dst) {
 #if defined(GGML_USE_HOPPER_Q1)
-  static const bool enabled = getenv("GGML_HOPPER_Q1") != nullptr;
-  if (!enabled) return false;
-  const int cc = ggml_cuda_info().devices[ctx.device].cc;
-  const int64_t K = src0->ne[0], N = src0->ne[1], M = src1->ne[1];
-  const bool is_q1 = src0->type == GGML_TYPE_Q1_0;
-  const bool is_q2 = src0->type == GGML_TYPE_Q2_0;
-  if (cc < 900 ||  // 900 = Hopper; no GGML_CUDA_CC_HOPPER macro in this tree
-       (!is_q1 && !is_q2) || src1->type != GGML_TYPE_F32 ||
-      dst->type != GGML_TYPE_F32 || src1->ne[2] * src1->ne[3] != 1 || src0->ne[2] * src0->ne[3] != 1 ||
-      (M % 128) || (N % 128) || (K % 128) || !ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
-    return false;
-  }
-  cudaStream_t stream = ctx.stream();
-  hopper_q1::DenseW wq = hopper_q1::get_dense_w(src0->data, (long)N, (long)K, is_q2 ? 2 : 1, ctx.device, stream);
-  ggml_cuda_pool_alloc<int8_t> act_q(ctx.pool(), (size_t)M * K);
-  ggml_cuda_pool_alloc<float> act_d(ctx.pool(), (size_t)M * (K / 128));
-  {
-    const int ngroups = (int)(M * (K / 128));
-    hopper_q1::quant_act_per128<<<(ngroups + 7) / 8, 256, 0, stream>>>((const float*)src1->data, act_q.get(),
-                                                                        act_d.get(), (int)M, (int)K);
-  }
-  constexpr int SMEM_BYTES = 2 * (hopper_q1::bM * hopper_q1::bK) + 2 * (hopper_q1::bN * hopper_q1::bK) +
-                             2 * (hopper_q1::bM + hopper_q1::bN) * (int)sizeof(float);
-  auto* kern_fixed = is_q2 ? hopper_q1::lowbit_wgmma_ggml<2> : hopper_q1::lowbit_wgmma_ggml<1>;
-  auto* kern_sk = is_q2 ? hopper_q1::lowbit_wgmma_ggml_sk<2> : hopper_q1::lowbit_wgmma_ggml_sk<1>;
-  // Both the dynamic-SMEM opt-in and the SM count are per-device; cache them per device
-  // so additional GPUs in a multi-GPU run don't skip the opt-in (launch failure) or
-  // reuse device 0's SM count (wrong stream-K dispatch / grid size).
-  static bool attr_set[GGML_CUDA_MAX_DEVICES] = {false};
-  if (!attr_set[ctx.device]) {
-    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<1>,    cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
-    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<2>,    cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
-    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<1>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
-    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<2>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
-    attr_set[ctx.device] = true;
-  }
-  const int ntm = (int)(M / hopper_q1::bM), ntn = (int)(N / hopper_q1::bN);
-  const int ntiles = ntm * ntn;
-  static int NSM[GGML_CUDA_MAX_DEVICES] = {0};
-  if (NSM[ctx.device] == 0) CUDA_CHECK(cudaDeviceGetAttribute(&NSM[ctx.device], cudaDevAttrMultiProcessorCount, ctx.device));
-  const int nsm = NSM[ctx.device];
-  if (ntiles < 8 * nsm) {
-    // starved grid -> stream-K (persistent; fp32-additive atomic flush into zeroed C)
-    const long total = (long)ntiles * (K / 128);
-    cudaMemsetAsync(dst->data, 0, (size_t)M * N * sizeof(float), stream);
-    kern_sk<<<nsm, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(),
-        wq.bits, wq.dw, (float*)dst->data, (int)M, (int)N, (int)K, ntn, total, nsm);
-  } else {
-    dim3 grid(ntm, ntn);
-    kern_fixed<<<grid, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(),
-        wq.bits, wq.dw, (float*)dst->data, (int)M, (int)N, (int)K);
-  }
-  return true;
+    static const bool enabled = getenv("GGML_HOPPER_Q1") != nullptr;
+    if (!enabled) {
+        return false;
+    }
+    const int     cc = ggml_cuda_info().devices[ctx.device].cc;
+    const int64_t K = src0->ne[0], N = src0->ne[1], M = src1->ne[1];
+    const bool    is_q1 = src0->type == GGML_TYPE_Q1_0;
+    const bool    is_q2 = src0->type == GGML_TYPE_Q2_0;
+    if (cc < 900 ||  // 900 = Hopper; no GGML_CUDA_CC_HOPPER macro in this tree
+        (!is_q1 && !is_q2) || src1->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32 ||
+        src1->ne[2] * src1->ne[3] != 1 || src0->ne[2] * src0->ne[3] != 1 || (M % 128) || (N % 128) || (K % 128) ||
+        !ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
+        return false;
+    }
+    cudaStream_t      stream = ctx.stream();
+    hopper_q1::DenseW wq = hopper_q1::get_dense_w(src0->data, (long) N, (long) K, is_q2 ? 2 : 1, ctx.device, stream);
+    ggml_cuda_pool_alloc<int8_t> act_q(ctx.pool(), (size_t) M * K);
+    ggml_cuda_pool_alloc<float>  act_d(ctx.pool(), (size_t) M * (K / 128));
+    {
+        const int ngroups = (int) (M * (K / 128));
+        hopper_q1::quant_act_per128<<<(ngroups + 7) / 8, 256, 0, stream>>>((const float *) src1->data, act_q.get(),
+                                                                           act_d.get(), (int) M, (int) K);
+    }
+    constexpr int SMEM_BYTES = 2 * (hopper_q1::bM * hopper_q1::bK) + 2 * (hopper_q1::bN * hopper_q1::bK) +
+                               2 * (hopper_q1::bM + hopper_q1::bN) * (int) sizeof(float);
+    auto *        kern_fixed = is_q2 ? hopper_q1::lowbit_wgmma_ggml<2> : hopper_q1::lowbit_wgmma_ggml<1>;
+    auto *        kern_sk    = is_q2 ? hopper_q1::lowbit_wgmma_ggml_sk<2> : hopper_q1::lowbit_wgmma_ggml_sk<1>;
+    // Both the dynamic-SMEM opt-in and the SM count are per-device; cache them per device
+    // so additional GPUs in a multi-GPU run don't skip the opt-in (launch failure) or
+    // reuse device 0's SM count (wrong stream-K dispatch / grid size).
+    static bool   attr_set[GGML_CUDA_MAX_DEVICES] = { false };
+    if (!attr_set[ctx.device]) {
+        CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<1>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                        SMEM_BYTES));
+        CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<2>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                        SMEM_BYTES));
+        CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<1>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                        SMEM_BYTES));
+        CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<2>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                        SMEM_BYTES));
+        attr_set[ctx.device] = true;
+    }
+    const int  ntm = (int) (M / hopper_q1::bM), ntn = (int) (N / hopper_q1::bN);
+    const int  ntiles                     = ntm * ntn;
+    static int NSM[GGML_CUDA_MAX_DEVICES] = { 0 };
+    if (NSM[ctx.device] == 0) {
+        CUDA_CHECK(cudaDeviceGetAttribute(&NSM[ctx.device], cudaDevAttrMultiProcessorCount, ctx.device));
+    }
+    const int nsm = NSM[ctx.device];
+    if (ntiles < 8 * nsm) {
+        // starved grid -> stream-K (persistent; fp32-additive atomic flush into zeroed C)
+        const long total = (long) ntiles * (K / 128);
+        cudaMemsetAsync(dst->data, 0, (size_t) M * N * sizeof(float), stream);
+        kern_sk<<<nsm, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(), wq.bits, wq.dw, (float *) dst->data,
+                                                  (int) M, (int) N, (int) K, ntn, total, nsm);
+    } else {
+        dim3 grid(ntm, ntn);
+        kern_fixed<<<grid, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(), wq.bits, wq.dw, (float *) dst->data,
+                                                      (int) M, (int) N, (int) K);
+    }
+    return true;
 #else
-  GGML_UNUSED(ctx); GGML_UNUSED(src0); GGML_UNUSED(src1); GGML_UNUSED(dst);
-  return false;
+    GGML_UNUSED(ctx);
+    GGML_UNUSED(src0);
+    GGML_UNUSED(src1);
+    GGML_UNUSED(dst);
+    return false;
 #endif
 }

--- a/ggml/src/ggml-cuda/mmq-hopper-q1.cu
+++ b/ggml/src/ggml-cuda/mmq-hopper-q1.cu
@@ -5,6 +5,7 @@
 // caller falls through to the standard MMQ path.
 #include "common.cuh"
 #include <unordered_map>
+#include <mutex>
 
 #if defined(GGML_USE_HOPPER_Q1)  // built only when CUTLASS include dir is provided
 #include <cuda_pipeline.h>
@@ -32,8 +33,13 @@ __global__ void quant_act_per128(const float* __restrict__ x, int8_t* __restrict
   for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
   const float scale = amax / 127.0f;
   const float inv = scale > 0.f ? 1.0f / scale : 0.f;
-  char4 out = make_char4((char)lrintf(v.x * inv), (char)lrintf(v.y * inv), (char)lrintf(v.z * inv),
-                         (char)lrintf(v.w * inv));
+  // scale maps |x|<=amax to <=127, so this cannot overflow in exact arithmetic;
+  // clamp anyway to be robust to fp rounding at the boundary.
+  auto q8 = [] (float f) -> signed char {
+    long r = lrintf(f);
+    return (signed char)(r < -127 ? -127 : (r > 127 ? 127 : r));
+  };
+  char4 out = make_char4(q8(v.x * inv), q8(v.y * inv), q8(v.z * inv), q8(v.w * inv));
   *(reinterpret_cast<char4*>(q + (size_t)m * K + kc * 128) + lane) = out;
   if (lane == 0) d[(size_t)m * (K / 128) + kc] = scale;
 }
@@ -64,22 +70,49 @@ __global__ void repack_q2_dense(const block_q2_0* __restrict__ W, unsigned* __re
 }
 
 struct DenseW { unsigned* bits; float* dw; };
-// experiment-grade cache: weights static for process lifetime; freed at exit by the driver.
+// Cache key: the weight pointer alone is ambiguous across devices and reshaped views,
+// so key on (device, wdata, N, K, wbits). Weights are static for the process lifetime;
+// the repacked buffers are freed at exit by the driver.
 // wbits = 1 (Q1_0 sign bits) or 2 (Q2_0 (q-1) fields); words per 128-block = 4*wbits.
-static DenseW get_dense_w(const void* wdata, long N, long K, int wbits, cudaStream_t stream) {
-  static std::unordered_map<const void*, DenseW> cache;
-  auto it = cache.find(wdata);
+struct DenseKey {
+  int device; const void* wdata; long N; long K; int wbits;
+  bool operator==(const DenseKey& o) const {
+    return device == o.device && wdata == o.wdata && N == o.N && K == o.K && wbits == o.wbits;
+  }
+};
+struct DenseKeyHash {
+  size_t operator()(const DenseKey& k) const {
+    size_t h = std::hash<const void*>()(k.wdata);
+    h ^= std::hash<long>()(k.N) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    h ^= std::hash<long>()(k.K) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    h ^= std::hash<int>()((k.device << 4) | k.wbits) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    return h;
+  }
+};
+static DenseW get_dense_w(const void* wdata, long N, long K, int wbits, int device, cudaStream_t stream) {
+  static std::unordered_map<DenseKey, DenseW, DenseKeyHash> cache;
+  static std::mutex cache_mutex;  // ggml may dispatch from one host thread per device concurrently
+  const DenseKey key{device, wdata, N, K, wbits};
+
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  auto it = cache.find(key);
   if (it != cache.end()) return it->second;
+
   DenseW d{};
   const long nb = N * (K / 128);
-  cudaMalloc(&d.bits, nb * 16 * wbits);
-  cudaMalloc(&d.dw, nb * sizeof(float));
+  CUDA_CHECK(cudaMalloc(&d.bits, nb * 16 * wbits));  // 4*wbits words/block, 4 B/word
+  CUDA_CHECK(cudaMalloc(&d.dw, nb * sizeof(float)));
   if (wbits == 1) {
     repack_q1_dense<<<(unsigned)((nb + 255) / 256), 256, 0, stream>>>((const block_q1_0*)wdata, d.bits, d.dw, nb);
   } else {
     repack_q2_dense<<<(unsigned)((nb + 255) / 256), 256, 0, stream>>>((const block_q2_0*)wdata, d.bits, d.dw, nb);
   }
-  cache.emplace(wdata, d);
+  // Publish only after repack is observably complete. A consumer GEMM may run on a
+  // different stream than the one used here, which would otherwise have no ordering
+  // dependency on the repack kernel and could read uninitialized dense buffers. The
+  // sync is one-time per (tensor,device); subsequent calls hit the cache.
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  cache.emplace(key, d);
   return d;
 }
 
@@ -340,7 +373,7 @@ bool ggml_cuda_mul_mat_q1_hopper(ggml_backend_cuda_context& ctx, const ggml_tens
     return false;
   }
   cudaStream_t stream = ctx.stream();
-  hopper_q1::DenseW wq = hopper_q1::get_dense_w(src0->data, (long)N, (long)K, is_q2 ? 2 : 1, stream);
+  hopper_q1::DenseW wq = hopper_q1::get_dense_w(src0->data, (long)N, (long)K, is_q2 ? 2 : 1, ctx.device, stream);
   ggml_cuda_pool_alloc<int8_t> act_q(ctx.pool(), (size_t)M * K);
   ggml_cuda_pool_alloc<float> act_d(ctx.pool(), (size_t)M * (K / 128));
   {
@@ -352,24 +385,28 @@ bool ggml_cuda_mul_mat_q1_hopper(ggml_backend_cuda_context& ctx, const ggml_tens
                              2 * (hopper_q1::bM + hopper_q1::bN) * (int)sizeof(float);
   auto* kern_fixed = is_q2 ? hopper_q1::lowbit_wgmma_ggml<2> : hopper_q1::lowbit_wgmma_ggml<1>;
   auto* kern_sk = is_q2 ? hopper_q1::lowbit_wgmma_ggml_sk<2> : hopper_q1::lowbit_wgmma_ggml_sk<1>;
-  static bool attr_set = false;
-  if (!attr_set) {
-    cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<1>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES);
-    cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<2>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES);
-    cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<1>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES);
-    cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<2>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES);
-    attr_set = true;
+  // Both the dynamic-SMEM opt-in and the SM count are per-device; cache them per device
+  // so additional GPUs in a multi-GPU run don't skip the opt-in (launch failure) or
+  // reuse device 0's SM count (wrong stream-K dispatch / grid size).
+  static bool attr_set[GGML_CUDA_MAX_DEVICES] = {false};
+  if (!attr_set[ctx.device]) {
+    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<1>,    cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
+    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml<2>,    cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
+    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<1>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
+    CUDA_CHECK(cudaFuncSetAttribute(hopper_q1::lowbit_wgmma_ggml_sk<2>, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_BYTES));
+    attr_set[ctx.device] = true;
   }
   const int ntm = (int)(M / hopper_q1::bM), ntn = (int)(N / hopper_q1::bN);
   const int ntiles = ntm * ntn;
-  static int NSM = 0;
-  if (NSM == 0) cudaDeviceGetAttribute(&NSM, cudaDevAttrMultiProcessorCount, ctx.device);
-  if (ntiles < 8 * NSM) {
+  static int NSM[GGML_CUDA_MAX_DEVICES] = {0};
+  if (NSM[ctx.device] == 0) CUDA_CHECK(cudaDeviceGetAttribute(&NSM[ctx.device], cudaDevAttrMultiProcessorCount, ctx.device));
+  const int nsm = NSM[ctx.device];
+  if (ntiles < 8 * nsm) {
     // starved grid -> stream-K (persistent; fp32-additive atomic flush into zeroed C)
     const long total = (long)ntiles * (K / 128);
     cudaMemsetAsync(dst->data, 0, (size_t)M * N * sizeof(float), stream);
-    kern_sk<<<NSM, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(),
-        wq.bits, wq.dw, (float*)dst->data, (int)M, (int)N, (int)K, ntn, total, NSM);
+    kern_sk<<<nsm, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(),
+        wq.bits, wq.dw, (float*)dst->data, (int)M, (int)N, (int)K, ntn, total, nsm);
   } else {
     dim3 grid(ntm, ntn);
     kern_fixed<<<grid, 512, SMEM_BYTES, stream>>>(act_q.get(), act_d.get(),


### PR DESCRIPTION
## What

Review follow-up for #39 (merged): multi-GPU correctness and hardening for the Hopper wgmma
path, plus a wholesale clang-format of the file. Fixes originate from the post-merge triage of
Copilot's inline review comments.

## Fixes

- **Repack cache**: keyed on `(device, wdata, N, K, wbits)` instead of the bare weight pointer
  (ambiguous across devices/views), guarded by a mutex (ggml can dispatch from one host thread
  per device), and entries publish only after a one-time `cudaStreamSynchronize` — a consumer
  GEMM on a different stream previously had no ordering dependency on the repack kernel and
  could read uninitialized dense buffers.
- **Per-device `attr_set` / SM count**: a second GPU previously skipped the dynamic-SMEM opt-in
  (launch failure) and inherited device 0's SM count (wrong stream-K grid).
- `CUDA_CHECK` on allocations and attribute/device queries.
- Defensive int8 clamp in the activation quantizer (unreachable in exact arithmetic — scale
  maps |x| <= amax to <= 127 — insurance against fp rounding at the boundary).
- **CMake**: `target_*`-scoped compile definitions/includes/options for the opt-in instead of
  directory-wide; option help text covers Q2_0.

## Verification (H100 SXM 80GB HBM3, single GPU)

- Configure with `-DGGML_CUDA_HOPPER_Q1=ON -DGGML_CUDA_CUTLASS_DIR=...`: clean (exercises the
  new target-scoped wiring)
- `test-backend-ops -o MUL_MAT` q1_0+q2_0: 86/86 OK — re-run after the clang-format commit too
- llama-bench pp512 vs stock MMQ: +8.1% (Q1_0), +7.4% (Q2_0) — perf-neutral vs pre-fix
  (mutex is off the hot path; the stream sync is once per tensor)

The multi-GPU changes are code-reviewed but verified on a single GPU only — no multi-GPU
Hopper box was available. The cache key, per-device attrs, and SM-count fixes are
straightforwardly correct by construction; flagging for whoever runs the next multi-GPU sweep.
