### PR TITLE
ci(release): resolve OpenMP redist DLL by glob instead of pinned MSVC version

### DIFF
--- a/.github/workflows/release-prism.yml
+++ b/.github/workflows/release-prism.yml
@@ -236,7 +236,13 @@ jobs:
 
       - name: Pack artifacts
         run: |
-          Copy-Item "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\debug_nonredist\${{ matrix.arch }}\Microsoft.VC143.OpenMP.LLVM\libomp140.${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}.dll" .\build\bin\Release\
+          # Resolve the LLVM OpenMP runtime DLL by glob: the MSVC redist version
+          # directory (and VS product dir) changes with runner-image updates, so a
+          # hardcoded path rots (upstream pins it and bumps it by hand each time).
+          $OmpDll = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\*\Enterprise\VC\Redist\MSVC\*\debug_nonredist\${{ matrix.arch }}\Microsoft.VC14*.OpenMP.LLVM\libomp140.${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}.dll" -ErrorAction SilentlyContinue | Sort-Object FullName | Select-Object -Last 1
+          if (-not $OmpDll) { throw "libomp140 DLL not found under any MSVC redist version" }
+          Write-Host "Using OpenMP runtime: $($OmpDll.FullName)"
+          Copy-Item $OmpDll.FullName .\build\bin\Release\
           7z a -snl llama-bin-win-cpu-${{ matrix.arch }}.zip .\build\bin\Release\*
 
       - name: Upload artifacts


### PR DESCRIPTION
## Problem

Today's Release (Prism) run [28762436839](https://github.com/PrismML-Eng/llama.cpp/actions/runs/28762436839) failed in `windows-cpu (arm64)` (and fail-fast cancelled `x64`):

```
Cannot find path 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\debug_nonredist\arm64\Microsoft.VC143.OpenMP.LLVM\libomp140.aarch64.dll'
```

The pack step hardcodes the MSVC redist version directory, which changes whenever GitHub updates the `windows-2025` runner image. Upstream has the same pattern and just bumps the pin by hand (currently `VS 18 / 14.51.36231 / VC145` on master).

## Fix

Glob the VS product dir, redist version, and `VC14*` toolset, pick the newest match, and fail with a clear message if nothing is found. Runner-image updates stop breaking the release build.

Note: a workflow-file change only takes effect on a fresh dispatch — re-running the failed jobs of the current run would still use the old definition. After merging, re-run **Release (Prism)** on `prism` with `create_release=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)