### PR TITLE
tests: add Q2_0 error thresholds to test-quantize-fns

### DIFF
--- a/tests/test-quantize-fns.cpp
+++ b/tests/test-quantize-fns.cpp
@@ -18,6 +18,9 @@ constexpr float MAX_QUANTIZATION_REFERENCE_ERROR = 0.0001f;
 constexpr float MAX_QUANTIZATION_TOTAL_ERROR = 0.002f;
 constexpr float MAX_QUANTIZATION_TOTAL_ERROR_BINARY = 0.025f;
 constexpr float MAX_QUANTIZATION_TOTAL_ERROR_TERNARY = 0.01f;
+// Q2_0 is a 2-bit block-scaled format (one fp16 scale per 128-element block, no zero-point), so its
+// error sits in the same band as the ternary formats rather than the k-quant 2-bit types below.
+constexpr float MAX_QUANTIZATION_TOTAL_ERROR_Q2_0 = 0.01f;
 constexpr float MAX_QUANTIZATION_TOTAL_ERROR_2BITS = 0.0075f;
 constexpr float MAX_QUANTIZATION_TOTAL_ERROR_3BITS = 0.0040f;
 constexpr float MAX_QUANTIZATION_TOTAL_ERROR_3BITS_XXS = 0.0050f;
@@ -27,6 +30,7 @@ constexpr float MAX_DOT_PRODUCT_ERROR_LOWBIT = 0.04f;
 constexpr float MAX_DOT_PRODUCT_ERROR_FP4 = 0.03f;
 constexpr float MAX_DOT_PRODUCT_ERROR_BINARY = 0.40f;
 constexpr float MAX_DOT_PRODUCT_ERROR_TERNARY = 0.15f;
+constexpr float MAX_DOT_PRODUCT_ERROR_Q2_0 = 0.15f;
 
 static const char* RESULT_STR[] = {"ok", "FAILED"};
 
@@ -148,6 +152,7 @@ int main(int argc, char * argv[]) {
             const float total_error = total_quantization_error(qfns, qfns_cpu, test_size, test_data.data());
             const float max_quantization_error =
                 type == GGML_TYPE_Q1_0    ? MAX_QUANTIZATION_TOTAL_ERROR_BINARY :
+                type == GGML_TYPE_Q2_0    ? MAX_QUANTIZATION_TOTAL_ERROR_Q2_0 :
                 type == GGML_TYPE_TQ1_0   ? MAX_QUANTIZATION_TOTAL_ERROR_TERNARY :
                 type == GGML_TYPE_TQ2_0   ? MAX_QUANTIZATION_TOTAL_ERROR_TERNARY :
                 type == GGML_TYPE_Q2_K    ? MAX_QUANTIZATION_TOTAL_ERROR_2BITS :
@@ -175,6 +180,8 @@ int main(int argc, char * argv[]) {
                                           ? MAX_DOT_PRODUCT_ERROR_LOWBIT
                                           : type == GGML_TYPE_Q1_0
                                           ? MAX_DOT_PRODUCT_ERROR_BINARY
+                                          : type == GGML_TYPE_Q2_0
+                                          ? MAX_DOT_PRODUCT_ERROR_Q2_0
                                           : type == GGML_TYPE_TQ1_0 || type == GGML_TYPE_TQ2_0
                                           ? MAX_DOT_PRODUCT_ERROR_TERNARY
                                           : type == GGML_TYPE_NVFP4


### PR DESCRIPTION
## What

`ctest` target **test-quantize-fns** fails on `prism` for the `q2_0` type:

```
q2_0 absolute quantization error:    FAILED (0.008678)
q2_0 dot product error:              FAILED (0.141111)
```

This reproduces on a clean `prism` checkout (CPU build, `-L main`) and is independent of PR #55 (DSpark) — it only shows up on PRs because the full CI matrix runs `ctest` on PRs but not on direct `prism` pushes. This PR fixes only that test.

## Root cause

`test-quantize-fns.cpp` keeps per-type error-threshold tables, but the `Q2_0` 2-bit quant type was never given an entry. It therefore fell through to the default thresholds (`MAX_QUANTIZATION_TOTAL_ERROR = 0.002`, `MAX_DOT_PRODUCT_ERROR = 0.02`), which are tuned for 4-bit-and-up formats. A 2-bit format cannot meet those, so the test failed deterministically on every platform (byte-identical values across ubuntu-arm64 / macos-arm64 / windows-x64 and locally). The last change to this file added the binary (`Q1_0`) and ternary thresholds but did not cover `Q2_0`.

## Fix

`Q2_0` stores one fp16 scale per 128-element block with no zero-point, so its error sits in the same band as the ternary formats — `tq1_0`/`tq2_0` measure `0.008681 / 0.141345` and pass at `0.01 / 0.15`. This adds matching dedicated `Q2_0` thresholds (`0.01` absolute, `0.15` dot product) and the corresponding branches, rather than loosening the shared 2-bit k-quant constant, so the existing `Q2_K` / `IQ2_S` checks are unchanged.

Measured `Q2_0` after the fix (headroom consistent with the ternary convention already in this file):

```
q2_0 absolute quantization error:    ok (0.008678)   [< 0.01]
q2_0 dot product error:              ok (0.141111)   [< 0.15]
```

## Verification

CPU build (`-DGGML_METAL=OFF -DGGML_CUDA=OFF -DLLAMA_BUILD_TESTS=ON -DLLAMA_CURL=OFF`):

- before: `test-quantize-fns` FAILED (2 sub-checks)
- after:  `test-quantize-fns` Passed; no other `-L main` regressions

## Scope note

The other red checks on PR #55's matrix were not genuine test failures: the windows-openblas/vulkan and ubuntu-x64 jobs were `The operation was canceled` (fail-fast after this failure), and macos-x64 was a transient boringssl fetch error. `test-quantize-fns` is the only real, reproducible failure and the only thing this PR touches.

---
AI usage: an AI coding assistant helped diagnose and draft this change; the diagnosis and fix were reviewed and verified locally.