### PR TITLE
dspark: add log-SNR embed support to the GGUF converter

### DIFF
--- a/conversion/dspark.py
+++ b/conversion/dspark.py
@@ -69,6 +69,8 @@ class DSparkModel(TextModel):
         "markov_head.down":      gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.DSPARK_MARKOV_HEAD_A],
         "markov_head.up":        gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.DSPARK_MARKOV_HEAD_B],
         "confidence_head":       gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.DSPARK_CONFIDENCE_HEAD],
+        "log_snr_embed.fc1":     gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.DSPARK_LOG_SNR_FC1],
+        "log_snr_embed.fc2":     gguf.TENSOR_NAMES[gguf.MODEL_TENSOR.DSPARK_LOG_SNR_FC2],
     }
 
     def set_gguf_parameters(self):
@@ -102,6 +104,18 @@ class DSparkModel(TextModel):
         conf_with_markov = hp.get("confidence_head_with_markov")
         if conf_with_markov is not None:
             self.gguf_writer.add_dspark_confidence_head_with_markov(bool(conf_with_markov))
+
+        log_snr_cond = hp.get("log_snr_conditioning")
+        if log_snr_cond is not None:
+            self.gguf_writer.add_dspark_log_snr_conditioning(bool(log_snr_cond))
+
+        min_log_snr = hp.get("min_log_snr")
+        if min_log_snr is not None:
+            self.gguf_writer.add_dspark_min_log_snr(float(min_log_snr))
+
+        max_log_snr = hp.get("max_log_snr")
+        if max_log_snr is not None:
+            self.gguf_writer.add_dspark_max_log_snr(float(max_log_snr))
 
         logger.info(
             "dspark: exported drafter (block_size=%d, target_layers=%s); "

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -134,6 +134,9 @@ class Keys:
         DSPARK_MARKOV_RANK                = "{arch}.dspark.markov_rank"
         DSPARK_CONFIDENCE_HEAD            = "{arch}.dspark.confidence_head"
         DSPARK_CONFIDENCE_WITH_MARKOV     = "{arch}.dspark.confidence_head_with_markov"
+        DSPARK_LOG_SNR_CONDITIONING       = "{arch}.dspark.log_snr_conditioning"
+        DSPARK_MIN_LOG_SNR                = "{arch}.dspark.min_log_snr"
+        DSPARK_MAX_LOG_SNR                = "{arch}.dspark.max_log_snr"
         NUM_DEEPSTACK_LAYERS              = "{arch}.n_deepstack_layers"
         DEEPSTACK_MAPPING                 = "{arch}.deepstack_mapping"
         POOLING_TYPE                      = "{arch}.pooling_type"
@@ -920,6 +923,8 @@ class MODEL_TENSOR(IntEnum):
     DSPARK_MARKOV_HEAD_A   = auto()
     DSPARK_MARKOV_HEAD_B   = auto()
     DSPARK_CONFIDENCE_HEAD = auto()
+    DSPARK_LOG_SNR_FC1     = auto()
+    DSPARK_LOG_SNR_FC2     = auto()
     # lfm2 audio
     A_ENC_NORM_CONV        = auto()
     A_ENC_LINEAR_POS       = auto()
@@ -1504,6 +1509,8 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.DSPARK_MARKOV_HEAD_A:      "dspark.markov_head_a",
     MODEL_TENSOR.DSPARK_MARKOV_HEAD_B:      "dspark.markov_head_b",
     MODEL_TENSOR.DSPARK_CONFIDENCE_HEAD:    "dspark.confidence_head",
+    MODEL_TENSOR.DSPARK_LOG_SNR_FC1:        "dspark.log_snr_fc1",
+    MODEL_TENSOR.DSPARK_LOG_SNR_FC2:        "dspark.log_snr_fc2",
 }
 
 MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
@@ -2270,6 +2277,8 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.DSPARK_MARKOV_HEAD_A,
         MODEL_TENSOR.DSPARK_MARKOV_HEAD_B,
         MODEL_TENSOR.DSPARK_CONFIDENCE_HEAD,
+        MODEL_TENSOR.DSPARK_LOG_SNR_FC1,
+        MODEL_TENSOR.DSPARK_LOG_SNR_FC2,
     ],
     MODEL_ARCH.QWEN35MOE: [
         MODEL_TENSOR.TOKEN_EMBD,

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -889,6 +889,15 @@ class GGUFWriter:
     def add_dspark_confidence_head_with_markov(self, value: bool) -> None:
         self.add_bool(Keys.LLM.DSPARK_CONFIDENCE_WITH_MARKOV.format(arch=self.arch), value)
 
+    def add_dspark_log_snr_conditioning(self, value: bool) -> None:
+        self.add_bool(Keys.LLM.DSPARK_LOG_SNR_CONDITIONING.format(arch=self.arch), value)
+
+    def add_dspark_min_log_snr(self, value: float) -> None:
+        self.add_float32(Keys.LLM.DSPARK_MIN_LOG_SNR.format(arch=self.arch), value)
+
+    def add_dspark_max_log_snr(self, value: float) -> None:
+        self.add_float32(Keys.LLM.DSPARK_MAX_LOG_SNR.format(arch=self.arch), value)
+
     def add_swin_norm(self, value: bool) -> None:
         self.add_bool(Keys.LLM.SWIN_NORM.format(arch=self.arch), value)
 


### PR DESCRIPTION
## What
Adds the log-SNR conditioning pieces to the Python GGUF conversion path: the `log_snr_embed.fc1/fc2` tensor mappings in `conversion/dspark.py`, the `DSPARK_LOG_SNR_FC1/FC2` tensor names and `log_snr_conditioning`/`min_log_snr`/`max_log_snr` KV keys in `gguf-py`, and the corresponding writer methods.

## Why
The C++ dspark loader merged in #55 already requires these tensors and KVs when a drafter is trained with log-SNR conditioning, but the converter never mapped them, so converting any log-SNR-conditioned drafter fails with:

    Can not map tensor 'log_snr_embed.fc1.bias'

All current-generation drafter checkpoints use log-SNR conditioning, so conversion from this repo is broken without this.

## How
Straight mapping additions, mirroring how the existing dspark markov/confidence tensors and KVs are wired. The KVs are only written when present in the source config, so older drafters convert unchanged. Verified by converting a current log-SNR drafter checkpoint and loading the result with the C++ loader (log_snr KVs present, 79 tensors bind).