### PR TITLE
metal: default-on nr1=2 multi-column Q2_0 matvec (spec-decode verify)

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -882,6 +882,13 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv(ggml_meta
                 if (nr1_force > 1 && ne11 >= 2) {
                     nr1 = std::min(nr1_force, 4);
                     suffix = nr1 == 2 ? "_nr1_2" : nr1 == 3 ? "_nr1_3" : "_nr1_4";
+                } else if (nr1_max != 1 && ne11 >= 2 && ne11 != 3) {
+                    // Default-on nr1=2 multi-column (mirrors the Q1_0 path above):
+                    // measured +31% at ne11=2 (93.2 vs 122 us) and a win at ne11=4
+                    // (2 passes, 171 vs 183). ne11==3 is carved out -- that is the
+                    // occupancy cliff (nr1_3 loses to ext) that kept this opt-in;
+                    // for 3 columns we stay on ext. GGML_METAL_Q2_0_NR1=1 disables.
+                    nr1 = 2; suffix = "_nr1_2";
                 }
             } break;
         case GGML_TYPE_Q4_0:


### PR DESCRIPTION
## What

Make the `nr1=2` multi-column Q2_0 matvec the **default** for `ne11 >= 2` (the small-batch / spec-decode verify path), mirroring the Q1_0 path — instead of requiring the opt-in `GGML_METAL_Q2_0_NR1` env var.

## Why

The `nr1=2` variant reads each streamed q2_0 weight group once per 2 `src1` columns, versus the `mul_mv_ext` route that re-streams per column. In-code microbench (M5 Pro): **nr1_2 = 93.2 µs vs 122 µs ext at ne11=2 (+31%)**; ne11=4 via 2 passes 171 vs 183. Q1_0 already defaults to this; this brings Q2_0 (ternary targets) to parity — it helps the DSpark **verify** path (which runs the target at ne11 = draft depth).

It was previously opt-in only because of the `nr1_3` **occupancy cliff** at `ne11==3` (195 vs 152 µs ext, tpb=16). This change carves out `ne11==3` (stays on ext), so only the measured-win widths engage.

## How

- `ne11 >= 2 && ne11 != 3` → `nr1=2`; `ne11==3` → unchanged (ext); `ne11==1` (base decode) → unchanged.
- `GGML_METAL_Q2_0_NR1=1` restores the old routing; `=2/3/4` still force as before.
- **Output-identical** — pure matvec routing, no numerics change.

## Testing

- Ternary base decode (llama-bench tg128, ne11=1): 27.06 → 27.13 tok/s = unchanged (change correctly scoped to multi-column).
- DSpark verify (tlg6l1 × ternary-cont6k, k=4), default settings now auto-engages nr1=2: runs clean, accept 0.757 / τ 4.03, output correct.
