### PR TITLE
clip: fix wrong-type format arguments (CodeQL high-severity)

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1640,7 +1640,7 @@ struct clip_model_loader {
                         get_arr_int(KEY_FEATURE_LAYER, hparams.vision_feature_layer);
                         get_arr_int(KEY_PROJ_SPATIAL_OFFSETS, hparams.proj_spatial_offsets);
                         if (hparams.vision_feature_layer.size() != hparams.proj_spatial_offsets.size()) {
-                            throw std::runtime_error(string_format("%s: vision_feature_layer.size() %d != proj_spatial_offsets.size() %d",
+                            throw std::runtime_error(string_format("%s: vision_feature_layer.size() %zu != proj_spatial_offsets.size() %zu", __func__,
                                                                    hparams.vision_feature_layer.size(), hparams.proj_spatial_offsets.size()));
                         }
 
@@ -2700,7 +2700,7 @@ struct clip_model_loader {
                     // Load separate layerwise and spatial projector tensors
                     const auto projector_count = hparams.vision_feature_layer.size();
                     model.qf_proj_blocks.resize(projector_count);
-                    for (size_t bid = 0; bid < projector_count; ++bid) {
+                    for (int bid = 0; bid < (int) projector_count; ++bid) {
                         auto & b = model.qf_proj_blocks[bid];
 
                         // non-layerwise tensors


### PR DESCRIPTION
## What

Fixes the two `cpp/wrong-type-format-argument` defects CodeQL flags as high-severity in `tools/mtmd/clip.cpp`:

1. The `vision_feature_layer.size() != proj_spatial_offsets.size()` error throw passed two `size_t` values to `%d` and had **no argument for its leading `%s`** (so the first size_t was formatted as the string). Now uses `%zu` for the sizes and passes `__func__` for `%s`.
2. The qwen-flamingo projector-block loop used `size_t bid`, passed to the `%d` in the `TN_QF_*` tensor-name format strings. Made `bid` an `int` so the format type matches (the tensor names are unchanged).

## Why

CodeQL reported these as new high-severity alerts on `prism`, failing the CodeQL check. Both are genuine format/argument type mismatches (UB / garbage output), not false positives.

## Test

`mtmd` target builds clean.
