### PR TITLE
perf(ggml-cpu): enable Q2_0 fast path on AVX-VNNI CPUs (3.2x on Intel 12th-14th gen)

### DIFF
--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -552,6 +552,12 @@ static inline __m128i get_scale_shuffle(int i) {
 }
 #endif
 
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+#  define GGML_DPBUSD_256 _mm256_dpbusd_epi32
+#elif defined(__AVXVNNI__)
+#  define GGML_DPBUSD_256 _mm256_dpbusd_avx_epi32
+#endif
+
 void ggml_vec_dot_q2_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK2_0;
     const int nb = n / qk;
@@ -568,8 +574,8 @@ void ggml_vec_dot_q2_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
 
     float sumf = 0.0f;
 
-#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
-    // AVX-512-VNNI: unpack 2-bit codes c in {0,1,2,3} (value = c-1), then
+#if (defined(__AVX512VNNI__) && defined(__AVX512VL__)) || defined(__AVXVNNI__)
+    // AVX-512-VNNI or AVX-VNNI: unpack 2-bit codes c in {0,1,2,3} (value = c-1), then
     // dot((c-1), qy) = dpbusd(c, qy) - dpbusd(1, qy).
     const __m256i ones   = _mm256_set1_epi8(1);
     const __m128i idxlo  = _mm_setr_epi8(0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3);
@@ -591,8 +597,8 @@ void ggml_vec_dot_q2_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
             r0 = _mm256_and_si256(_mm256_srli_epi16(_mm256_mullo_epi16(r0, mul), 6), three);
             r1 = _mm256_and_si256(_mm256_srli_epi16(_mm256_mullo_epi16(r1, mul), 6), three);
             __m256i codes = _mm256_permute4x64_epi64(_mm256_packus_epi16(r0, r1), 0xD8); // 32 codes in order
-            const int dp = hsum_i32_8(_mm256_dpbusd_epi32(_mm256_setzero_si256(), codes, qy));
-            const int sy = hsum_i32_8(_mm256_dpbusd_epi32(_mm256_setzero_si256(), ones,  qy));
+            const int dp = hsum_i32_8(GGML_DPBUSD_256(_mm256_setzero_si256(), codes, qy));
+            const int sy = hsum_i32_8(GGML_DPBUSD_256(_mm256_setzero_si256(), ones,  qy));
             sumi += d1 * (float)(dp - sy);
         }
         sumf += d0 * sumi;


### PR DESCRIPTION
## Problem

`ggml_vec_dot_q2_0_q8_0` (`ggml/src/ggml-cpu/arch/x86/quants.c`) gates its VNNI fast path on:

```c
#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
```

There is no AVX2/AVX-VNNI fallback, so every x86 CPU without AVX-512 silently takes the scalar loop.

This excludes **all Intel consumer CPUs from 12th–14th gen** (Alder Lake / Raptor Lake), where AVX-512 is fused off because of the P/E hybrid design — but which *do* have AVX-VNNI. That looks like a large share of the "on-device / runs on a standard laptop" x86 audience Bonsai targets. (AMD Zen 4/5 expose AVX512-VNNI and are unaffected, which may be why this went unnoticed.)

Symptom on such a host: prompt-eval throughput equals decode throughput, i.e. the per-token `vec_dot` dominates and batching gains nothing.

## Fix

The fast-path body is already entirely 256-bit AVX2 — the only AVX-512 dependency is the `_mm256_dpbusd_epi32` intrinsic. AVX-VNNI exposes the identical operation as `_mm256_dpbusd_avx_epi32`, so this aliases the intrinsic and widens the guard.

**No algorithmic change, and no behavior change on AVX-512-VNNI hosts** (same path, same intrinsic).

## Results

Intel i5-13400 (Raptor Lake, 6P+4E, AVX-VNNI, **no** AVX-512), 12 threads, Debian 13, CPU-only build (`-DGGML_NATIVE=ON`). Same model, same prompt, `temperature=0`; the kernel is the only variable (controlled A/B: patch applied, reverted, rebuilt, re-applied).

| Model | metric | before | after | speedup |
|---|---|---:|---:|---:|
| `Ternary-Bonsai-8B` Q2_0 | decode | 2.17 tok/s | **6.92 tok/s** | **3.2x** |
| `Ternary-Bonsai-8B` Q2_0 | prompt eval | 2.7 tok/s | **8.6 tok/s** | **3.2x** |

Repeat run after re-applying: 6.85 tok/s decode / 8.4 tok/s prompt (consistent).

With the patch, `Ternary-Bonsai-4B` Q2_0 reaches **12.4 tok/s** decode / 16.2 tok/s prompt on the same host — which moves ternary Bonsai from "unusable" to "usable" on mainstream Intel desktops.

For reference, unpatched `Ternary-Bonsai-27B` Q2_0 runs at 0.69 tok/s on this host.

## Verification

- `echo | gcc -march=native -dM -E -` on this host defines `__AVXVNNI__=1` and `__AVX2__=1`, with no `__AVX512VNNI__` — confirming the scalar path was taken before.
- `vpdpbusd` instruction count in `libggml-cpu.so`: **353 → 361** (the 8 added are the two Q2_0 call sites), confirming the fast path is compiled in.
- Generated output verified coherent before and after, on the identical prompt.

## Notes / open questions

- The macro name `GGML_DPBUSD_256` is arbitrary — happy to rename or switch to an inline helper if you prefer.
- Only compile-time dispatch is handled, matching the surrounding code's pattern. Builds using `GGML_CPU_ALL_VARIANTS` (runtime dispatch) may need an AVX-VNNI variant added to the variant list; I have not tested that path.
- I only tested `Q2_0`. `Q1_0` may have the same gating issue but I have not verified it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
