### PR TITLE
ci(release): full self-contained Windows Vulkan/HIP bundles + README fork note

### DIFF
--- a/.github/workflows/release-prism.yml
+++ b/.github/workflows/release-prism.yml
@@ -412,12 +412,14 @@ jobs:
 
       - name: Build
         run: |
-          cmake -S . -B build -DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_CPU=OFF -DGGML_BACKEND_DL=ON -DLLAMA_BUILD_BORINGSSL=ON
-          cmake --build build --config Release --target ggml-vulkan
+          # Full self-contained bundle (CPU backends + Vulkan), not just the ggml-vulkan.dll
+          # add-on, so users can download this one zip and run without merging with the CPU zip.
+          cmake -S . -B build -DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON -DGGML_OPENMP=OFF -DLLAMA_BUILD_BORINGSSL=ON
+          cmake --build build --config Release
 
       - name: Pack artifacts
         run: |
-          7z a -snl llama-bin-win-vulkan-x64.zip .\build\bin\Release\ggml-vulkan.dll
+          7z a -snl llama-bin-win-vulkan-x64.zip .\build\bin\Release\*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
@@ -581,12 +583,13 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DGGML_BACKEND_DL=ON `
             -DGGML_NATIVE=OFF `
-            -DGGML_CPU=OFF `
+            -DGGML_OPENMP=OFF `
             -DGPU_TARGETS="${{ matrix.gpu_targets }}" `
             -DGGML_HIP_ROCWMMA_FATTN=ON `
             -DGGML_HIP=ON `
             -DLLAMA_BUILD_BORINGSSL=ON
-          cmake --build build --target ggml-hip -j ${env:NUMBER_OF_PROCESSORS}
+          # Full self-contained bundle (CPU backend + HIP), not just the ggml-hip.dll add-on.
+          cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
           md "build\bin\rocblas\library\"
           md "build\bin\hipblaslt\library"
           cp "${env:HIP_PATH}\bin\libhipblas.dll" "build\bin\"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # llama.cpp
 
+> [!IMPORTANT]
+> **This is the PrismML fork of llama.cpp.** It adds the `Q2_0` / `PQ2_0` 2-bit quantization used by the [Bonsai](https://huggingface.co/collections/prism-ml/bonsai) models.
+>
+> **New here? Start with the [Bonsai-demo](https://github.com/PrismML-Eng/Bonsai-demo) repo** — it downloads the right model files and the correct prebuilt binaries for your hardware/backend automatically.
+>
+> If you use this fork directly, the main caveats:
+> - **Use a complete matching build** — download the full bundle for your OS+backend from our [Releases](https://github.com/PrismML-Eng/llama.cpp/releases), or build from source. Do **not** drop this fork's `ggml-*` libraries into a stock llama.cpp build (ABI mismatch — this will fail to load models).
+> - **Models:** use the `*-Q2_0_g64.gguf` files (official **group-64** `Q2_0`). The legacy `*-Q2_0.gguf` (group 128) won't load on group-64 builds; `*-PQ2_0.gguf` is this fork's group-128 variant.
+> - `Q2_0` is already upstream in mainline llama.cpp for **CPU and Metal** — those work without this fork. Vulkan/CUDA come from this fork for now.
+
+---
+
 ![llama](https://user-images.githubusercontent.com/1991296/230134379-7181e485-c521-4d23-a0d6-f7b3b61ba524.png)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # llama.cpp
 
 > [!IMPORTANT]
-> **This is the PrismML fork of llama.cpp.** It adds the `Q2_0` / `PQ2_0` 2-bit quantization used by the [Bonsai](https://huggingface.co/collections/prism-ml/bonsai) models.
+> **This is the PrismML fork of llama.cpp.** It adds the `Q2_0` 2-bit quantization used by the [Bonsai](https://huggingface.co/collections/prism-ml/bonsai) models.
 >
-> **New here? Start with the [Bonsai-demo](https://github.com/PrismML-Eng/Bonsai-demo) repo** — it downloads the right model files and the correct prebuilt binaries for your hardware/backend automatically.
+> **New here? Start with the [Bonsai-demo](https://github.com/PrismML-Eng/Bonsai-demo) repo.** It downloads the right models and the correct prebuilt binaries for your hardware/backend automatically.
 >
-> If you use this fork directly, the main caveats:
-> - **Use a complete matching build** — download the full bundle for your OS+backend from our [Releases](https://github.com/PrismML-Eng/llama.cpp/releases), or build from source. Do **not** drop this fork's `ggml-*` libraries into a stock llama.cpp build (ABI mismatch — this will fail to load models).
-> - **Models:** use the `*-Q2_0_g64.gguf` files (official **group-64** `Q2_0`). The legacy `*-Q2_0.gguf` (group 128) won't load on group-64 builds; `*-PQ2_0.gguf` is this fork's group-128 variant.
-> - `Q2_0` is already upstream in mainline llama.cpp for **CPU and Metal** — those work without this fork. Vulkan/CUDA come from this fork for now.
+> Ternary (`Q2_0`) support is migrating into mainline llama.cpp backend-by-backend, so which build + model file to use depends on where you run:
+>
+> - `*-Q2_0.gguf` (group size 128): the format **this fork** uses. Run it with this fork's builds / [releases](https://github.com/PrismML-Eng/llama.cpp/releases). Does not load on mainline llama.cpp.
+> - `*-Q2_0_g64.gguf` (group size 64): the **official mainline** llama.cpp format (currently CPU and Metal). Use a recent `ggml-org/llama.cpp` build for these, not this fork.
+> - `*-PQ2_0.gguf`: planned future fork format, **not supported anywhere yet**.
+>
+> Use a complete matching build. Do NOT drop this fork's `ggml-*` libraries into a stock llama.cpp build (ABI/format mismatch, models fail to load).
+>
+> **For the latest backend-by-backend migration status, see [Upstream Status for Ternary](https://github.com/PrismML-Eng/Bonsai-demo#upstream-status-for-ternary) in the Bonsai-demo README.**
 
 ---
 


### PR DESCRIPTION
## What

Two fixes prompted by [#71](https://github.com/PrismML-Eng/llama.cpp/issues/71) (a user couldn't run the Windows Vulkan release — it shipped only `ggml-vulkan.dll`, and grafting it onto stock llama.cpp failed with an ABI/offset mismatch):

1. **Windows Vulkan & HIP releases now ship complete, self-contained bundles.**
   Previously these jobs built with `-DGGML_CPU=OFF --target ggml-<backend>` and packed only the
   single backend DLL — an add-on that had to be merged into the CPU zip. Now they build the full
   set (CPU backends + the GPU backend) and pack the whole `build/bin`, so one download runs out of
   the box. This matches what the Linux `ubuntu-vulkan` job already does.
   - `windows-vulkan`: build with `GGML_CPU_ALL_VARIANTS=ON -DGGML_VULKAN=ON` (dropped `GGML_CPU=OFF`
     and `--target ggml-vulkan`), pack `build/bin/Release/*`.
   - `windows-hip`: dropped `GGML_CPU=OFF`, full build (dropped `--target ggml-hip`); pack already
     included the whole `build/bin`.
   - `GGML_OPENMP=OFF` on both to avoid an extra OpenMP runtime DLL dependency in the bundle.

2. **README fork note.** Many users land on this fork directly (not the Bonsai-demo). Added a note
   at the top: start with Bonsai-demo; use a complete matching build (don't mix our libs into stock
   llama.cpp); use `*-Q2_0_g64.gguf` models (group-64 official Q2_0) vs legacy `*-Q2_0.gguf` (g128)
   / `*-PQ2_0.gguf`.

## Note
Windows CI can't be built locally (no Windows here) — relying on this PR's CI to validate the
Vulkan/HIP full builds. Targeting `prism` (production) as requested; migration to newer prism branch
later.

Closes #71 (once released).
