### PR TITLE
test: fix -Werror=format in test-arg-parser download test

### DIFF
--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -196,7 +196,7 @@ int main(void) {
                 assert(str.find("llama.cpp") != std::string::npos);
                 network_ok = true;
             } else {
-                printf("  good URL returned %d, no usable network -- skipping download tests\n\n", res.first);
+                printf("  good URL returned %ld, no usable network -- skipping download tests\n\n", res.first);
             }
         } catch (const std::exception & e) {
             printf("  good URL unreachable (%s) -- skipping download tests\n\n", e.what());


### PR DESCRIPTION
## What

Format the HTTP status code in the `test-arg-parser` download-skip message with `%ld` instead of `%d`.

## Why

`common_remote_get_content()` returns the status as `long` (`std::pair<long, std::vector<char>>`). The skip-path `printf` used `%d`, which fails to build under `-Werror=format` on the CUDA CI toolchain:

```
tests/test-arg-parser.cpp:199:46: error: format '%d' expects argument of type 'int',
but argument 2 has type 'long int' [-Werror=format=]
```

This breaks the `cuda` build job (and cascades the self-hosted GPU/CPU jobs into cancellation) on any branch built on `prism`, independent of that branch's own changes.

## How

One-line change: `%d` -> `%ld` at the call site. No behavior change.
