### PR TITLE
server: do not propagate --kv-mean-center bias to draft model contexts

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -901,6 +901,10 @@ private:
                     params_dft.cache_type_k          = params_spec.cache_type_k;
                     params_dft.cache_type_v          = params_spec.cache_type_v;
                     params_dft.tensor_buft_overrides = params_spec.tensor_buft_overrides;
+                    // the K-cache mean-center bias is calibrated for the target model
+                    // (per-head/channel K layout); the draft model has a different K
+                    // geometry, so it must not inherit the bias
+                    params_dft.kv_mean_center_path.clear();
                 } else {
                     // MTP draft context lives on the target model, only context+compute are new
                     measure_model_bytes = false;
@@ -991,6 +995,10 @@ private:
             params_dft.n_gpu_layers = params_spec.n_gpu_layers;
             params_dft.cache_type_k = params_spec.cache_type_k;
             params_dft.cache_type_v = params_spec.cache_type_v;
+            // the K-cache mean-center bias is calibrated for the target model
+            // (per-head/channel K layout); the draft model has a different K
+            // geometry, so it must not inherit the bias
+            params_dft.kv_mean_center_path.clear();
 
             if (params_spec.cpuparams.n_threads > 0) {
                 params_dft.cpuparams.n_threads       = params_spec.cpuparams.n_threads;


### PR DESCRIPTION
## Problem

`--kv-mean-center` sets `common_params.kv_mean_center_path` globally. The server builds draft-model params by copying the whole struct (`auto params_dft = params_base;`), so when a draft model is loaded via `-md`, both the draft VRAM-measurement probe and the real draft context inherit the bias path. The bias GGUF is calibrated for the *target* model's K geometry, so draft context creation fails:

- with default f16 draft KV: `llama_init_from_model: path_kv_mean_center requires the K cache type to be Q4_0 (got f16)`
- with `-ctkd q4_0`: `load_kv_mean_center: bias tensor kv_bar.blk.3.k has 1024 elements, expected 512 (n_embd_head_k * n_head_kv)`

Either way the probe reports `[spec] failed to measure draft model memory` and speculative decoding is silently disabled (`common_speculative_init: no implementations specified`) — making `--kv-mean-center` and `-md` mutually exclusive in practice.

## Fix

Clear `kv_mean_center_path` on the copied draft params at both construction sites in `tools/server/server-context.cpp` (the VRAM-measurement probe and the real draft context), following the existing pattern of draft-specific overrides (`cache_type_k`/`cache_type_v`). The main context keeps the bias.

Coverage note: the only consumption site is `common_context_params_to_llama` (`common/common.cpp`), and these are the only two non-main-context derivations of `common_params` in the server for the `-md` path (the MTP branch shares the target model and is untouched).

## Verified

RTX A5000, Ternary-Bonsai-27B Q2_0 + dspark drafter + `--kv-mean-center` + q4_0 KV (`-ctkd/-ctvd q4_0`), based on `62061f9`:
- bias loads for the main model only, no `load_kv_mean_center` errors
- `common_speculative_impl_draft_dspark: adding speculative implementation 'draft-dspark'` — spec active alongside the bias
- greedy decode ~59 tok/s with drafter vs ~48 AR; BFCL simple_python 95.0% with drafter vs 95.25% without (quality unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)