### PR TITLE
cuda: extract Q2_0 elements via __byte_perm

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -425,43 +425,28 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
         }
 
         const block_q2_0 * bxi = (const block_q2_0 *) x + kbx0 + i*stride + kbx;
-        // Each 32-element chunk occupies 8 bytes of qs (32 elements * 2 bits = 64 bits)
-        const int qs_offset = 8*kqsx;
-        const int qs0 = bxi->qs[qs_offset + 0] | (bxi->qs[qs_offset + 1] << 8) |
-                        (bxi->qs[qs_offset + 2] << 16) | (bxi->qs[qs_offset + 3] << 24);
-        const int qs1 = bxi->qs[qs_offset + 4] | (bxi->qs[qs_offset + 5] << 8) |
-                        (bxi->qs[qs_offset + 6] << 16) | (bxi->qs[qs_offset + 7] << 24);
-
-        // Unpack 32 2-bit codes into 8 int32s, each holding 4 signed int8s in {-1,0,1,2}.
-        int unpacked_bytes[8];
-#pragma unroll
-        for (int j = 0; j < 4; ++j) {
-            const int shift = j * 8;
-            const int codes = (qs0 >> shift) & 0xFF;
-            const int c0 = ((codes >> 0) & 0x3) - 1;
-            const int c1 = ((codes >> 2) & 0x3) - 1;
-            const int c2 = ((codes >> 4) & 0x3) - 1;
-            const int c3 = ((codes >> 6) & 0x3) - 1;
-            unpacked_bytes[j] = (c0 & 0xFF) | ((c1 & 0xFF) << 8) | ((c2 & 0xFF) << 16) | ((c3 & 0xFF) << 24);
-        }
-#pragma unroll
-        for (int j = 0; j < 4; ++j) {
-            const int shift = j * 8;
-            const int codes = (qs1 >> shift) & 0xFF;
-            const int c0 = ((codes >> 0) & 0x3) - 1;
-            const int c1 = ((codes >> 2) & 0x3) - 1;
-            const int c2 = ((codes >> 4) & 0x3) - 1;
-            const int c3 = ((codes >> 6) & 0x3) - 1;
-            unpacked_bytes[4 + j] = (c0 & 0xFF) | ((c1 & 0xFF) << 8) | ((c2 & 0xFF) << 16) | ((c3 & 0xFF) << 24);
-        }
+        // each 32-element chunk occupies 8 bytes of qs (4 int16), regardless of group size
+        const int16_t    * qxi = (const int16_t *) bxi->qs + kqsx * 4;
 
         const int dst_offset = kbx*(scale_entries_per_block*QI8_0) + kqsx*QI8_0;
+
 #pragma unroll
-        for (int j = 0; j < 8; ++j) {
+        for (int j = 0; j < 4; ++j) {
+            const int q  = qxi[j];
+
+            // unpack even and odd crumbs into byte values
+            const int qe = __byte_perm(0x020100FF, 0x020100FF, q >> 0);
+            const int qo = __byte_perm(0x020100FF, 0x020100FF, q >> 2);
+            // unshuffle values
+            const int qx = __byte_perm(qe, qo, 0x5140);
+            const int qy = __byte_perm(qe, qo, 0x7362);
+
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + dst_offset + j] = unpacked_bytes[j];
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + dst_offset + j*2+0] = qx;
+            x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + dst_offset + j*2+1] = qy;
 #else
-            x_qs[i*(2*MMQ_TILE_NE_K + 1) + dst_offset + j] = unpacked_bytes[j];
+            x_qs[i*(2*MMQ_TILE_NE_K + 1) + dst_offset + j*2+0] = qx;
+            x_qs[i*(2*MMQ_TILE_NE_K + 1) + dst_offset + j*2+1] = qy;
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
         }
     }

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -746,58 +746,35 @@ static __device__ __forceinline__ float vec_dot_q2_0_q8_1(
     // Q8_1: 32 elements per block with individual scales
     // iqs selects which of the 4 chunks of 32 elements to process (0-3)
 
-    const float d2 = bq2_0->d;
+    const float     d2 = bq2_0->d;
+    // each 32-element chunk occupies 8 bytes of qs (4 int16), regardless of group size
+    const int16_t * qs = (const int16_t *) bq2_0->qs + iqs * 4;
 
     // Process only the chunk specified by iqs
     const block_q8_1 * bq8_1_chunk = bq8_1 + iqs;
 
-    // Load 64 bits (8 bytes) for this chunk from Q2_0: bytes [8*iqs, 8*iqs+8)
-    const int offset = iqs * 8;
-    const int v0 = bq2_0->qs[offset + 0] | (bq2_0->qs[offset + 1] << 8) |
-                   (bq2_0->qs[offset + 2] << 16) | (bq2_0->qs[offset + 3] << 24);
-    const int v1 = bq2_0->qs[offset + 4] | (bq2_0->qs[offset + 5] << 8) |
-                   (bq2_0->qs[offset + 6] << 16) | (bq2_0->qs[offset + 7] << 24);
-
-    // Unpack 32 2-bit codes into 8 int32s of raw UNSIGNED codes {0,1,2,(3)} --
-    // no per-element "-1" offset. Symbol s = code - 1, so sum(s*act) =
-    // sum(code*act) - sum(act); that correction is applied once at the end
-    // instead (matches the deferred-correction pattern vec_dot_q4_0_q8_1_impl
-    // uses -- code 3 is unreachable from the reference quantizer, so this
-    // covers the only codes {0,1,2} that ever actually occur).
-    int vi_bytes[8];
-#pragma unroll
-    for (int j = 0; j < 4; ++j) {
-        const int shift = j * 8;
-        const int codes = (v0 >> shift) & 0xFF;
-        const int c0    = (codes >> 0) & 0x3;
-        const int c1    = (codes >> 2) & 0x3;
-        const int c2    = (codes >> 4) & 0x3;
-        const int c3    = (codes >> 6) & 0x3;
-        vi_bytes[j]     = c0 | (c1 << 8) | (c2 << 16) | (c3 << 24);
-    }
-#pragma unroll
-    for (int j = 0; j < 4; ++j) {
-        const int shift = j * 8;
-        const int codes = (v1 >> shift) & 0xFF;
-        const int c0    = (codes >> 0) & 0x3;
-        const int c1    = (codes >> 2) & 0x3;
-        const int c2    = (codes >> 4) & 0x3;
-        const int c3    = (codes >> 6) & 0x3;
-        vi_bytes[4 + j] = c0 | (c1 << 8) | (c2 << 16) | (c3 << 24);
-    }
-
-    // Compute dot product for this 32-element chunk
     int sumi = 0;
 #pragma unroll
-    for (int j = 0; j < 8; ++j) {
-        const int u = get_int_b4(bq8_1_chunk->qs, j);
-        sumi = ggml_cuda_dp4a(vi_bytes[j], u, sumi);
+    for (int j = 0; j < 4; ++j) {
+        const int q  = qs[j];
+        const int u  = get_int_b4(bq8_1_chunk->qs, j*2+0);
+        const int v  = get_int_b4(bq8_1_chunk->qs, j*2+1);
+
+        // the permute source 0x020100FF holds bytes {-1,0,1,2}, so a 2-bit code
+        // indexes straight to its symbol (s = code - 1) with no arithmetic
+        const int qe = __byte_perm(0x020100FF, 0x020100FF, q >> 0);
+        const int qo = __byte_perm(0x020100FF, 0x020100FF, q >> 2);
+        // unshuffle values
+        const int qx = __byte_perm(qe, qo, 0x5140);
+        const int qy = __byte_perm(qe, qo, 0x7362);
+
+        sumi = ggml_cuda_dp4a(u, qx, sumi);
+        sumi = ggml_cuda_dp4a(v, qy, sumi);
     }
 
-    // ds.x = d8 (per-block activation scale), ds.y = sum(act) in real units
-    // (see quantize_q8_1: y[ib].ds = make_half2(d, sum)).
-    const float2 ds8f = __half22float2(bq8_1_chunk->ds);
-    return d2 * (sumi * ds8f.x - ds8f.y);
+    // symbols are already signed, so no deferred sum(act) correction is needed
+    const float d8 = __low2float(bq8_1_chunk->ds);
+    return d2 * d8 * sumi;
 }
 
 static __device__ __forceinline__ float vec_dot_q4_0_q8_1(


### PR DESCRIPTION
## What

Ports upstream's `__byte_perm` element extraction for `Q2_0` into this fork, covering both the MMVQ decode path (`vec_dot_q2_0_q8_1`) and the MMQ prefill tile-load.

Provenance: ggml-org/llama.cpp#25603, upstream commit `15e755f30`, "cuda: extract Q2_0 elements via `__byte_perm`" by David Friehs. Upstream applies it to their group-size-64 `Q2_0`; this fork's `Q2_0` uses a different group size, so the port is adapted rather than cherry-picked. Upstream also moved their tile-load into `mmq-load-tiles.cuh` during the MMQ refactor, while ours is still in `mmq.cuh`, so `git cherry-pick` does not apply.

## Why it ports across group sizes unchanged

The technique consumes 4 `int16_t` (8 bytes, 32 two-bit codes) per Q8_1 chunk. That chunk size is set by Q8_1's 32-element block, not by `QK2_0`, so the `iqs * 4` indexing is identical either way. Only the number of chunks differs, which the caller drives.

The permute source `0x020100FF` holds bytes `{-1, 0, 1, 2}`, so a 2-bit code indexes straight to its symbol with no arithmetic.

Two details worth keeping if this code is touched again:

- The cast must stay `int16_t`. `qs` begins at byte offset 2, right after `ggml_half d`, so it is only 2-byte aligned and an `int32_t` cast would be misaligned.
- The LUT operand is deliberately duplicated. PTX `prmt` treats selector bit 3 as a sign-replicate flag, and `q >> 2` shifts sign bits in; duplicating the operand makes both harmless. This was checked exhaustively rather than reasoned about, see below.

## Numerics

The decode path previously summed unsigned codes and applied a deferred `-sum(act)` correction in the tail. `__byte_perm` produces signed symbols directly, so the tail becomes `d2 * d8 * sumi`. Both forms reduce to `d2 * d8 * sum((c-1) * q8)`. The MMQ path already stored signed bytes and is a like-for-like swap.

Because that tail change is the kind of "obviously equivalent" refactor that can quietly break numerics, it was verified rather than argued:

| check | result |
|---|---|
| `test-backend-ops -b CUDA0 -o MUL_MAT` | zero failures, same as base |
| `test-backend-ops -b CUDA0 -o MUL_MAT_ID` | zero failures |
| greedy generation vs unpatched, short prompt | byte-identical |
| greedy generation vs unpatched, long prompt forcing the MMQ tile path | byte-identical |
| standalone: all 65536 `int16` inputs vs a scalar reference | bit-exact, 65536/65536 |
| standalone: signed tail vs old unsigned-plus-correction tail, 200k random chunks including the unreachable code | 0 disagreements |

`MUL_MAT` coverage spans n=1..64, so both the MMVQ and MMQ paths are exercised.

## Performance

Validated internally on Hopper, interleaved arms with multiple rounds, and confirmed at kernel level by profiler traces showing both the MMQ and MMVQ kernels for this type getting faster. It helps both prefill and decode.

It was originally measured on a dense model and later re-measured on a routed-expert MoE, since the MoE dispatches through `mul_mat_id` and MMQ-ID paths that the first measurement did not exercise. It holds there too, with a negative control on the other low-bit type sitting in the noise, confirming the gain is specific to this change rather than environmental. Gains are smaller on the MoE, which is expected, since routed-expert matmul is a smaller share of its decode time. Numbers are in the internal notes rather than here.

## Notes for review

- Formatting follows upstream's text exactly rather than `clang-format`'s preference on two lines, so the two versions stay easy to diff and future upstream changes remain cherry-pickable. The surrounding declarations in `vecdotq.cuh` already use the same single-space pointer style.
- No behaviour change for any other quantization type; only this type's paths are touched.
