### PR TITLE
prism-v6: fix Q2_0_g128 ARM link failure and Metal shader compile

### DIFF
--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -73,6 +73,8 @@
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
+// quants.c
+#define ggml_vec_dot_q2_0_g128_q8_0_generic ggml_vec_dot_q2_0_g128_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_K_4x4_generic ggml_quantize_mat_q8_K_4x4
 #define ggml_quantize_mat_q8_K_4x8_generic ggml_quantize_mat_q8_K_4x8

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -212,6 +212,7 @@
 // quants.c
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
+#define ggml_vec_dot_q2_0_g128_q8_0_generic ggml_vec_dot_q2_0_g128_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x1_generic ggml_quantize_mat_q8_0_4x1
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -3881,6 +3881,7 @@ void kernel_mul_mv_q2_0_f32_impl(
     }
 }
 
+template<int nr0, typename args_t>
 void kernel_mul_mv_q2_0_g128_f32_impl(
         args_t args,
         device const char * src0,


### PR DESCRIPTION
## What

Two one-line fixes for the Q2_0_g128 port on prism-v6:

1. `ggml-cpu/arch-fallback.h`: add the missing aarch64 alias mapping `ggml_vec_dot_q2_0_g128_q8_0` to its generic implementation. Without it every ARM build of prism-v6 fails to link, since `type_traits_cpu` references the symbol unconditionally. Every other arch without a native g128 dot already carries this line.
2. `ggml-metal.metal`: restore the `template<int nr0, typename args_t>` prefix on `kernel_mul_mv_q2_0_g128_f32_impl`. It was dropped in the port, so the Metal library failed to compile at runtime on every Apple device, for every model.

## Why

Closes out the "Metal: ported, UNVERIFIED" line on the prism-v6 status board. The port could not previously build on ARM or run on Metal at all.

## How verified (M5 Pro)

- `test-quantize-fns` green including q2_0_g128
- `test-backend-ops`: MUL_MAT 45/45 g128 cases OK across 3 backends; MUL_MAT_ID, GET_ROWS, CPY green (covers the mul_mv 8-sub-block and nl=8 risk spots)
- Real model: F16 quantized with `--pure Q2_0_G128`, greedy output byte-identical to the same model at g64; tg128 280.8 vs 278.9 t/s (+0.7%) at a 5.6% smaller file
- Regression check: Q1_0 27B loads and generates correctly, pp512 441.8 / tg128 39.2 t/s, about 9% faster than the same-day upstream master build on identical hardware
