### PR TITLE
prism-v6: complete Q2_0_g128 switch coverage in ops.cpp (fixes -Werror=switch CI)

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -666,6 +666,7 @@ void ggml_compute_forward_add(
             } break;
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q2_0:
+        case GGML_TYPE_Q2_0_G128:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
         case GGML_TYPE_Q5_0:
@@ -1117,6 +1118,7 @@ void ggml_compute_forward_add1(
             } break;
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q2_0:
+        case GGML_TYPE_Q2_0_G128:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
         case GGML_TYPE_Q5_0:
@@ -1248,6 +1250,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_BF16:
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q2_0:
+        case GGML_TYPE_Q2_0_G128:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
         case GGML_TYPE_Q5_0:
@@ -4799,6 +4802,7 @@ void ggml_compute_forward_set(
         case GGML_TYPE_BF16:
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q2_0:
+        case GGML_TYPE_Q2_0_G128:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
         case GGML_TYPE_Q5_0:
@@ -5782,6 +5786,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_BF16:
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q2_0:
+        case GGML_TYPE_Q2_0_G128:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
         case GGML_TYPE_Q5_0:


### PR DESCRIPTION
## What

Adds `GGML_TYPE_Q2_0_G128` to the five remaining unsupported-type switch lists in `ggml-cpu/ops.cpp`, alongside the existing `Q2_0` cases, with the same abort behavior as the other quant types.

## Why

These switches are fatal under `-Werror=switch`, which is exactly what is failing the macos-arm64, macos-x64, ubuntu-arm64, and ubuntu-x64 CI jobs on prism-v6 right now (first hit is `ggml_compute_forward_clamp` at ops.cpp:5773; the other four sites would fail serially after it). Follow-up to #113, which fixed the ARM link and Metal shader compile but did not cover these.

## How verified

- `GGML_FATAL_WARNINGS=ON` local build of ggml-cpu: zero warnings
- Repo sweep for other switches enumerating `Q2_0` without `Q2_0_G128`: none remaining on the CPU side; SYCL and Vulkan hits are the known not-yet-ported backends whose dispatch switches carry defaults, and their CI jobs pass
