### PR TITLE
llama/ggml: explicit signs, latent embeddings, grouped out_proj for the Hadamard contract

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -680,21 +680,35 @@ class ModelBase:
             r")\.weight"
         )
         weight_names: list[str] = []
+        inverse_weight_names: list[str] = []
         for record in tensor_records:
             if not isinstance(record, dict) or not isinstance(record.get("name"), str):
                 raise ValueError("Hadamard manifest has an invalid tensor record")
             if record.get("axis") != -1:
                 raise ValueError(f"Unsupported Hadamard tensor axis for {record['name']!r}")
+            role = record.get("role", "fold-before-matmul")
+            if role not in ("fold-before-matmul", "inverse-after-lookup"):
+                raise ValueError(f"Unsupported Hadamard tensor role for {record['name']!r}: {role!r}")
             filtered = self.filter_tensors((record["name"], lambda: None))
             if filtered is None:
                 raise ValueError(f"Hadamard tensor is filtered out: {record['name']!r}")
             mapped = self.map_tensor_name(filtered[0])
-            if not _HADAMARD_KINDS.fullmatch(mapped):
-                raise ValueError(
-                    f"Hadamard tensor {record['name']!r} maps to {mapped!r}, which is not on a "
-                    "verified Hadamard-aware matmul path"
-                )
-            weight_names.append(mapped)
+            if role == "inverse-after-lookup":
+                # the runtime applies the inverse transform only to the token-embedding
+                # lookup; any other latent table would load and silently stay rotated
+                if mapped != "token_embd.weight":
+                    raise ValueError(
+                        f"Hadamard tensor {record['name']!r} maps to {mapped!r}, which is not a "
+                        "verified inverse-after-lookup table"
+                    )
+                inverse_weight_names.append(mapped)
+            else:
+                if not _HADAMARD_KINDS.fullmatch(mapped):
+                    raise ValueError(
+                        f"Hadamard tensor {record['name']!r} maps to {mapped!r}, which is not on a "
+                        "verified Hadamard-aware matmul path"
+                    )
+                weight_names.append(mapped)
 
         self.gguf_writer.add_uint32("prism.hadamard.version", 1)
         self.gguf_writer.add_uint32("prism.hadamard.block_size", block_size)
@@ -705,8 +719,10 @@ class ModelBase:
         if sign_mode == "explicit":
             self.gguf_writer.add_array("prism.hadamard.sign_widths", sign_widths)
             self.gguf_writer.add_array("prism.hadamard.sign_values", sign_values)
-        logger.info("GGUF Hadamard contract: H%d, sign_mode=%s, %d folded weight(s)",
-                    block_size, sign_mode, len(weight_names))
+        if inverse_weight_names:
+            self.gguf_writer.add_array("prism.hadamard.inverse_weight_names", inverse_weight_names)
+        logger.info("GGUF Hadamard contract: H%d, sign_mode=%s, %d folded weight(s), %d inverse-lookup",
+                    block_size, sign_mode, len(weight_names), len(inverse_weight_names))
 
     def set_gguf_parameters(self):
         raise NotImplementedError("set_gguf_parameters() must be implemented in subclasses")

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -620,7 +620,8 @@ class ModelBase:
         with manifest_path.open("r", encoding="utf-8") as f:
             manifest = json.load(f)
 
-        if manifest.get("schema_version") != 1 or manifest.get("kind") != "hadamard-weight-fold":
+        schema_version = manifest.get("schema_version")
+        if schema_version not in (1, 2) or manifest.get("kind") != "hadamard-weight-fold":
             raise ValueError(f"Unsupported Hadamard manifest: {manifest_path}")
         if manifest.get("status") != "requires-matching-runtime":
             raise ValueError(f"Unexpected Hadamard manifest status: {manifest.get('status')!r}")
@@ -633,11 +634,21 @@ class ModelBase:
             raise ValueError(f"Invalid Hadamard block size: {block_size!r}")
         if transform.get("name") != "normalized-signed-sylvester-walsh-hadamard":
             raise ValueError(f"Unsupported Hadamard transform: {transform.get('name')!r}")
-        if transform.get("sign_mode") != "identity":
-            raise ValueError(
-                "GGUF Hadamard runtime currently supports only identity signs; "
-                "repack with --sign-mode identity"
-            )
+        sign_mode = transform.get("sign_mode")
+        if sign_mode not in ("identity", "explicit"):
+            raise ValueError(f"Unsupported Hadamard sign mode: {sign_mode!r}")
+        sign_widths: list[int] = []
+        sign_values: list[int] = []
+        if sign_mode == "explicit":
+            signs = manifest.get("signs")
+            if not isinstance(signs, dict) or not signs:
+                raise ValueError("explicit sign mode requires a signs table")
+            for width_str, vec in sorted(signs.items(), key=lambda kv: int(kv[0])):
+                width = int(width_str)
+                if len(vec) != width or any(v not in (-1, 1) for v in vec):
+                    raise ValueError(f"invalid sign vector for width {width}")
+                sign_widths.append(width)
+                sign_values.extend(int(v) for v in vec)
 
         tensor_records = manifest.get("tensors")
         if not isinstance(tensor_records, list) or not tensor_records:
@@ -689,9 +700,13 @@ class ModelBase:
         self.gguf_writer.add_uint32("prism.hadamard.block_size", block_size)
         self.gguf_writer.add_string("prism.hadamard.transform", "normalized-sylvester-walsh-hadamard")
         self.gguf_writer.add_string("prism.hadamard.axis", "input-last-dimension")
-        self.gguf_writer.add_string("prism.hadamard.sign_mode", "identity")
+        self.gguf_writer.add_string("prism.hadamard.sign_mode", sign_mode)
         self.gguf_writer.add_array("prism.hadamard.weight_names", weight_names)
-        logger.info("GGUF Hadamard contract: H%d for %d folded weight(s)", block_size, len(weight_names))
+        if sign_mode == "explicit":
+            self.gguf_writer.add_array("prism.hadamard.sign_widths", sign_widths)
+            self.gguf_writer.add_array("prism.hadamard.sign_values", sign_values)
+        logger.info("GGUF Hadamard contract: H%d, sign_mode=%s, %d folded weight(s)",
+                    block_size, sign_mode, len(weight_names))
 
     def set_gguf_parameters(self):
         raise NotImplementedError("set_gguf_parameters() must be implemented in subclasses")

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -687,8 +687,9 @@ class ModelBase:
                 "the runtime would load the GGUF without applying the activation transform"
             )
         _HADAMARD_KINDS = re.compile(
+            r"output\.weight|"
             r"blk\.\d+\.("
-            r"attn_q|attn_k|attn_v|attn_qkv|attn_output"
+            r"attn_q|attn_k|attn_v|attn_qkv|attn_gate|attn_output"
             r"|ffn_gate|ffn_up|ffn_down"
             r"|ffn_gate_exps|ffn_up_exps|ffn_down_exps|ffn_gate_up_exps"
             r"|ffn_gate_shexp|ffn_up_shexp|ffn_down_shexp"

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -611,6 +611,21 @@ class ModelBase:
             raise ValueError(f"Can not map tensor {name!r}")
         return new_name
 
+    def hadamard_folded_names(self) -> set[str]:
+        """Source-tensor names folded under a Hadamard manifest, or empty."""
+        cached = getattr(self, "_hadamard_folded_names", None)
+        if cached is not None:
+            return cached
+        names: set[str] = set()
+        manifest_path = self.dir_model / "hadamard_packing.json"
+        if manifest_path.is_file():
+            with manifest_path.open("r", encoding="utf-8") as f:
+                for record in json.load(f).get("tensors", []):
+                    if isinstance(record, dict) and isinstance(record.get("name"), str):
+                        names.add(record["name"])
+        self._hadamard_folded_names = names
+        return names
+
     def add_hadamard_metadata(self) -> None:
         """Transfer a packed-checkpoint transform contract into GGUF metadata."""
         manifest_path = self.dir_model / "hadamard_packing.json"
@@ -677,6 +692,7 @@ class ModelBase:
             r"|ffn_gate|ffn_up|ffn_down"
             r"|ffn_gate_exps|ffn_up_exps|ffn_down_exps|ffn_gate_up_exps"
             r"|ffn_gate_shexp|ffn_up_shexp|ffn_down_shexp"
+            r"|ssm_out"
             r")\.weight"
         )
         weight_names: list[str] = []
@@ -721,6 +737,9 @@ class ModelBase:
             self.gguf_writer.add_array("prism.hadamard.sign_values", sign_values)
         if inverse_weight_names:
             self.gguf_writer.add_array("prism.hadamard.inverse_weight_names", inverse_weight_names)
+        if getattr(self, "_hadamard_gdn_v_grouped", False):
+            self.gguf_writer.add_bool("prism.hadamard.gdn_v_grouped", True)
+            logger.info("GGUF Hadamard: linear-attention out_proj kept in grouped V order")
         logger.info("GGUF Hadamard contract: H%d, sign_mode=%s, %d folded weight(s), %d inverse-lookup",
                     block_size, sign_mode, len(weight_names), len(inverse_weight_names))
 

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -597,7 +597,11 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
                 data_torch = torch.cat([qk_part, v_part], dim=0)
 
             elif ".out_proj." in name:
-                if name in self.hadamard_folded_names():
+                # the tensor name may have had wrapper prefixes stripped by the
+                # time it reaches modify_tensors, so match manifest entries by
+                # suffix rather than exact name
+                suffix = "linear_attn.out_proj.weight"
+                if name.endswith(suffix) and any(n.endswith(suffix) for n in self.hadamard_folded_names()):
                     # Hadamard-folded latent: the rotation axis must keep the
                     # training (grouped) V order; the runtime permutes the
                     # activation tiled->grouped before the transform instead.

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -597,8 +597,14 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
                 data_torch = torch.cat([qk_part, v_part], dim=0)
 
             elif ".out_proj." in name:
-                # Out projection weight: reorder columns (input dimension)
-                data_torch = self._reorder_v_heads(data_torch, 1, num_k_heads, num_v_per_k, head_v_dim)
+                if name in self.hadamard_folded_names():
+                    # Hadamard-folded latent: the rotation axis must keep the
+                    # training (grouped) V order; the runtime permutes the
+                    # activation tiled->grouped before the transform instead.
+                    self._hadamard_gdn_v_grouped = True
+                else:
+                    # Out projection weight: reorder columns (input dimension)
+                    data_torch = self._reorder_v_heads(data_torch, 1, num_k_heads, num_v_per_k, head_v_dim)
 
         yield from super().modify_tensors(data_torch, name, bid)
 

--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -11,9 +11,10 @@ __device__ __forceinline__ float fwht_load<half>(const half value) {
     return __half2float(value);
 }
 
-template <int N, typename T>
+template <int N, typename T, bool has_signs>
 __launch_bounds__(4*ggml_cuda_get_physical_warp_size(), 1)
-__global__ void fwht_cuda(const T * src, float * dst, const int64_t n_rows, const float scale) {
+__global__ void fwht_cuda(const T * src, float * dst, const int64_t n_rows, const float scale,
+                          const float * signs, const int n_blk) {
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     const int64_t r = (int64_t) blockIdx.x * blockDim.y + threadIdx.y;
@@ -30,9 +31,13 @@ __global__ void fwht_cuda(const T * src, float * dst, const int64_t n_rows, cons
     const int lane = threadIdx.x;
 
     ggml_cuda_pdl_sync();
+    const float * signs_row = has_signs ? signs + (r % n_blk) * N : nullptr;
 #pragma unroll
     for (int i = 0; i < el_w; ++i) {
         reg[i] = fwht_load(src[i * warp_size + lane]) * scale;
+        if (has_signs) {
+            reg[i] *= signs_row[i * warp_size + lane];
+        }
     }
 
 #pragma unroll
@@ -68,81 +73,78 @@ __global__ void fwht_cuda(const T * src, float * dst, const int64_t n_rows, cons
     }
 }
 
-bool ggml_cuda_op_fwht(ggml_backend_cuda_context & ctx, const ggml_tensor * src, ggml_tensor * dst) {
-    GGML_ASSERT(ggml_are_same_shape(src, dst));
+template <typename T>
+static bool fwht_launch(ggml_backend_cuda_context & ctx, const T * src_d, float * dst_d,
+                        const int n, const int64_t rows, const float scale,
+                        const float * signs, const int n_blk) {
+    const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
+    const int rows_per_block = 4;
+    const int64_t num_blocks = (rows + rows_per_block - 1) / rows_per_block;
+    cudaStream_t stream = ctx.stream();
+    dim3 grid_dims(num_blocks, 1, 1);
+    dim3 block_dims(warp_size, rows_per_block, 1);
+    const ggml_cuda_kernel_launch_params launch_params =
+        ggml_cuda_kernel_launch_params(grid_dims, block_dims, 0, stream);
+
+    switch (n) {
+#define FWHT_CASE(NN) \
+        case NN: \
+            if (signs) { \
+                ggml_cuda_kernel_launch(fwht_cuda<NN, T, true>,  launch_params, src_d, dst_d, rows, scale, signs, n_blk); \
+            } else { \
+                ggml_cuda_kernel_launch(fwht_cuda<NN, T, false>, launch_params, src_d, dst_d, rows, scale, nullptr, 1); \
+            } \
+            return true;
+        FWHT_CASE(64)
+        FWHT_CASE(128)
+        FWHT_CASE(256)
+        FWHT_CASE(512)
+        FWHT_CASE(1024)
+        FWHT_CASE(2048)
+#undef FWHT_CASE
+        default:
+            return false;
+    }
+}
+
+static bool fwht_dispatch(ggml_backend_cuda_context & ctx, const ggml_tensor * src, ggml_tensor * dst,
+                          const ggml_tensor * signs_t) {
+    GGML_ASSERT(ggml_nelements(src) == ggml_nelements(dst));
     if (!ggml_is_contiguous(src) || !ggml_is_contiguous(dst)) {
         return false;
     }
-    const int     n    = src->ne[0];
-    const int64_t rows = ggml_nrows(src);
+    const int     n    = dst->ne[0];
+    const int64_t rows = ggml_nelements(dst) / n;
 
     if ((src->type != GGML_TYPE_F32 && src->type != GGML_TYPE_F16) || dst->type != GGML_TYPE_F32) {
         return false;
     }
 
-    const void * src_d = src->data;
-    float *       dst_d = (float *) dst->data;
+    const float * signs = nullptr;
+    int n_blk = 1;
+    if (signs_t) {
+        if (signs_t->type != GGML_TYPE_F32 || !ggml_is_contiguous(signs_t) || signs_t->ne[0] % n != 0) {
+            return false;
+        }
+        signs = (const float *) signs_t->data;
+        n_blk = signs_t->ne[0] / n;
+    }
 
-    const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
-    const int rows_per_block = 4;
-
-    const int64_t num_blocks = (rows + rows_per_block - 1) / rows_per_block;
-
-    cudaStream_t                         stream = ctx.stream();
-    dim3                                 grid_dims(num_blocks, 1, 1);
-    dim3                                 block_dims(warp_size, rows_per_block, 1);
-    const ggml_cuda_kernel_launch_params launch_params =
-        ggml_cuda_kernel_launch_params(grid_dims, block_dims, 0, stream);
-
+    float * dst_d = (float *) dst->data;
     const float scale = 1 / sqrtf(n);
 
     if (src->type == GGML_TYPE_F32) {
-        const float * src_f32 = (const float *) src_d;
-        switch (n) {
-            case 64:
-                ggml_cuda_kernel_launch(fwht_cuda<64, float>, launch_params, src_f32, dst_d, rows, scale);
-                return true;
-            case 128:
-                ggml_cuda_kernel_launch(fwht_cuda<128, float>, launch_params, src_f32, dst_d, rows, scale);
-                return true;
-            case 256:
-                ggml_cuda_kernel_launch(fwht_cuda<256, float>, launch_params, src_f32, dst_d, rows, scale);
-                return true;
-            case 512:
-                ggml_cuda_kernel_launch(fwht_cuda<512, float>, launch_params, src_f32, dst_d, rows, scale);
-                return true;
-            case 1024:
-                ggml_cuda_kernel_launch(fwht_cuda<1024, float>, launch_params, src_f32, dst_d, rows, scale);
-                return true;
-            case 2048:
-                ggml_cuda_kernel_launch(fwht_cuda<2048, float>, launch_params, src_f32, dst_d, rows, scale);
-                return true;
-            default:
-                return false;
-        }
+        return fwht_launch<float>(ctx, (const float *) src->data, dst_d, n, rows, scale, signs, n_blk);
     }
+    return fwht_launch<half>(ctx, (const half *) src->data, dst_d, n, rows, scale, signs, n_blk);
+}
 
-    const half * src_f16 = (const half *) src_d;
-    switch (n) {
-        case 64:
-            ggml_cuda_kernel_launch(fwht_cuda<64, half>, launch_params, src_f16, dst_d, rows, scale);
-            return true;
-        case 128:
-            ggml_cuda_kernel_launch(fwht_cuda<128, half>, launch_params, src_f16, dst_d, rows, scale);
-            return true;
-        case 256:
-            ggml_cuda_kernel_launch(fwht_cuda<256, half>, launch_params, src_f16, dst_d, rows, scale);
-            return true;
-        case 512:
-            ggml_cuda_kernel_launch(fwht_cuda<512, half>, launch_params, src_f16, dst_d, rows, scale);
-            return true;
-        case 1024:
-            ggml_cuda_kernel_launch(fwht_cuda<1024, half>, launch_params, src_f16, dst_d, rows, scale);
-            return true;
-        case 2048:
-            ggml_cuda_kernel_launch(fwht_cuda<2048, half>, launch_params, src_f16, dst_d, rows, scale);
-            return true;
-        default:
-            return false;
-    }
+bool ggml_cuda_op_fwht(ggml_backend_cuda_context & ctx, const ggml_tensor * src, ggml_tensor * dst) {
+    GGML_ASSERT(ggml_are_same_shape(src, dst));
+    return fwht_dispatch(ctx, src, dst, nullptr);
+}
+
+bool ggml_cuda_op_fwht_signed(ggml_backend_cuda_context & ctx, const ggml_tensor * src,
+                              const ggml_tensor * signs, ggml_tensor * dst) {
+    return fwht_dispatch(ctx, src, dst, signs);
 }

--- a/ggml/src/ggml-cuda/fwht.cuh
+++ b/ggml/src/ggml-cuda/fwht.cuh
@@ -2,3 +2,5 @@
 
 // Returns whether the Fast Walsh-Hadamard transform could be used.
 bool ggml_cuda_op_fwht(ggml_backend_cuda_context & ctx, const ggml_tensor * src, ggml_tensor * dst);
+bool ggml_cuda_op_fwht_signed(ggml_backend_cuda_context & ctx, const ggml_tensor * src,
+                              const ggml_tensor * signs, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3254,6 +3254,29 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         }
     }
 
+    // Hadamard sign flip + reshape + FWHT-hint matmul: multiply the sign
+    // vector during the transform's load instead of a separate full pass
+    if (ggml_can_fuse_subgraph(cgraph, i, { GGML_OP_MUL, GGML_OP_RESHAPE, GGML_OP_MUL_MAT }, { i + 2 })) {
+        const ggml_tensor * mul     = cgraph->nodes[i];
+        const ggml_tensor * reshape = cgraph->nodes[i + 1];
+        ggml_tensor *       mm      = cgraph->nodes[i + 2];
+
+        const ggml_tensor * x     = mul->src[0];
+        const ggml_tensor * signs = mul->src[1];
+
+        const bool pattern_ok = ggml_get_op_params_i32(mm, 1) == GGML_HINT_SRC0_IS_HADAMARD &&
+            mm->src[1] == reshape && reshape->src[0] == mul &&
+            signs->ne[1] == 1 && signs->ne[2] == 1 && signs->ne[3] == 1 &&
+            signs->type == GGML_TYPE_F32 && mul->type == GGML_TYPE_F32 &&
+            (x->type == GGML_TYPE_F32 || x->type == GGML_TYPE_F16) &&
+            ggml_is_contiguous(x) && ggml_is_contiguous(signs) &&
+            signs->ne[0] == x->ne[0] && signs->ne[0] % mm->src[0]->ne[0] == 0;
+
+        if (pattern_ok && ggml_cuda_op_fwht_signed(*cuda_ctx, x, signs, mm)) {
+            return 2;
+        }
+    }
+
     //RoPE + view + set-rows
     if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_ROPE, GGML_OP_VIEW, GGML_OP_SET_ROWS }, {})) {
         ggml_tensor * rope     = cgraph->nodes[i];

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -82,6 +82,16 @@ static void llama_verify_hadamard_graph(
 
     for (const auto & [node, ok] : lookups) {
         if (!ok) {
+            for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
+                const ggml_tensor * n2 = ggml_graph_node(gf, i);
+                for (int s = 0; s < GGML_MAX_SRC && n2->src[s]; ++s) {
+                    if (unwrap(n2->src[s]) == node) {
+                        LLAMA_LOG_WARN("%s: latent lookup '%s' consumed by op=%s name='%s' src%d hint=%d\n",
+                                __func__, node->name, ggml_op_name(n2->op), n2->name, s,
+                                ((const int32_t *) n2->op_params)[1]);
+                    }
+                }
+            }
             throw std::runtime_error(format(
                 "Hadamard-latent table '%s' is read without the inverse transform",
                 node->src[0]->name));
@@ -736,12 +746,6 @@ void llama_context::sched_reserve() {
 
         n_splits_pp = ggml_backend_sched_get_n_splits(sched.get());
         n_nodes_pp  = ggml_graph_n_nodes(gf);
-
-        // a folded weight consumed without its activation-side transform loads
-        // cleanly but computes wrong results; refuse to run such a graph
-        if (!model.hadamard_rotations.empty() || !model.hadamard_inverses.empty()) {
-            llama_verify_hadamard_graph(gf, model.hadamard_rotations, model.hadamard_inverses);
-        }
     }
 
     // reserve with tg (token generation) graph to get the number of splits and nodes
@@ -2510,6 +2514,13 @@ ggml_cgraph * llama_context::graph_reserve(
     res->reset();
 
     auto * gf = model.build_graph(gparams);
+
+    // verify transform coverage on the pristine graph: after scheduling,
+    // cross-backend copies break the producer chain the check follows
+    if (!hadamard_verified && gf && (!model.hadamard_rotations.empty() || !model.hadamard_inverses.empty())) {
+        llama_verify_hadamard_graph(gf, model.hadamard_rotations, model.hadamard_inverses);
+        hadamard_verified = true;
+    }
 
     this->n_outputs = save_n_outputs;
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2479,6 +2479,7 @@ llm_graph_params llama_context::graph_params(
         /*.mctx        =*/ mctx,
         /*.cross       =*/ &cross,
         /*.hadamard_rotations =*/ &model.hadamard_rotations,
+        /*.hadamard_inverses  =*/ &model.hadamard_inverses,
         /*.samplers    =*/ sampling.samplers,
         /*.n_outputs   =*/ n_outputs,
         /*.cb          =*/ graph_get_cb(),

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -27,6 +27,68 @@
 // llama_context
 //
 
+// Verify that every Hadamard-folded weight consumed by the graph receives its
+// activation-side transform, and every latent lookup table gets the inverse.
+// An architecture whose matmul path bypasses the transform helpers would
+// otherwise load cleanly and silently compute wrong results.
+static void llama_verify_hadamard_graph(
+        ggml_cgraph * gf,
+        const llama_hadamard_rotations & rotations,
+        const llama_hadamard_rotations & inverses) {
+    auto unwrap = [](const ggml_tensor * t) {
+        while (t && (t->op == GGML_OP_RESHAPE || t->op == GGML_OP_VIEW)) {
+            t = t->src[0];
+        }
+        return t;
+    };
+
+    std::map<const ggml_tensor *, bool> lookups; // get_rows results of latent tables
+
+    for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
+        const ggml_tensor * node = ggml_graph_node(gf, i);
+
+        if (node->op == GGML_OP_GET_ROWS && inverses.count(node->src[0])) {
+            lookups.emplace(node, false);
+            continue;
+        }
+
+        if (node->op != GGML_OP_MUL_MAT && node->op != GGML_OP_MUL_MAT_ID) {
+            continue;
+        }
+
+        if (node->op == GGML_OP_MUL_MAT && ((const int32_t *) node->op_params)[1] == GGML_HINT_SRC0_IS_HADAMARD) {
+            const auto lk = lookups.find(unwrap(node->src[1]));
+            if (lk != lookups.end()) {
+                lk->second = true;
+            }
+            continue;
+        }
+
+        const auto it = rotations.find(node->src[0]);
+        if (it == rotations.end()) {
+            continue;
+        }
+        const ggml_tensor * src = unwrap(node->src[1]);
+        const bool transformed = src && src->op == GGML_OP_MUL_MAT &&
+            ((const int32_t *) src->op_params)[1] == GGML_HINT_SRC0_IS_HADAMARD &&
+            src->src[0] == it->second.rot;
+        if (!transformed) {
+            throw std::runtime_error(format(
+                "Hadamard-folded weight '%s' is consumed without its activation transform; "
+                "this graph's matmul path does not support prism.hadamard folding",
+                node->src[0]->name));
+        }
+    }
+
+    for (const auto & [node, ok] : lookups) {
+        if (!ok) {
+            throw std::runtime_error(format(
+                "Hadamard-latent table '%s' is read without the inverse transform",
+                node->src[0]->name));
+        }
+    }
+}
+
 static llm_graph_type ctx_type_to_graph_type(llama_context_type ctx_type) {
     switch (ctx_type) {
         case LLAMA_CONTEXT_TYPE_DEFAULT: return LLM_GRAPH_TYPE_DEFAULT;
@@ -674,6 +736,12 @@ void llama_context::sched_reserve() {
 
         n_splits_pp = ggml_backend_sched_get_n_splits(sched.get());
         n_nodes_pp  = ggml_graph_n_nodes(gf);
+
+        // a folded weight consumed without its activation-side transform loads
+        // cleanly but computes wrong results; refuse to run such a graph
+        if (!model.hadamard_rotations.empty() || !model.hadamard_inverses.empty()) {
+            llama_verify_hadamard_graph(gf, model.hadamard_rotations, model.hadamard_inverses);
+        }
     }
 
     // reserve with tg (token generation) graph to get the number of splits and nodes

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -367,6 +367,9 @@ private:
     llm_graph_result_ptr gf_res_prev;
     llm_graph_result_ptr gf_res_reserve;
 
+    // one-time Hadamard transform-coverage check on the first built graph
+    bool hadamard_verified = false;
+
     // host buffer for the model output (logits and embeddings)
     ggml_backend_buffer_ptr buf_output;
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1462,6 +1462,7 @@ llm_graph_context::llm_graph_context(const llm_graph_params & params) :
     mctx             (params.mctx),
     cross            (params.cross),
     hadamard_rotations(params.hadamard_rotations),
+    hadamard_inverses (params.hadamard_inverses),
     samplers         (params.samplers),
     cb_func          (params.cb),
     res              (params.res),
@@ -2312,6 +2313,18 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
         auto & cur = inps[0];
 
         cur = ggml_get_rows(ctx0, tok_embd, inp->tokens);
+
+        // a Hadamard-latent embedding table stores rotated rows; restore the
+        // primal basis right after the lookup: h = s * (H z)
+        if (hadamard_inverses) {
+            const auto it = hadamard_inverses->find(tok_embd);
+            if (it != hadamard_inverses->end()) {
+                cur = llama_mul_mat_hadamard(ctx0, cur, it->second.rot);
+                if (it->second.signs) {
+                    cur = ggml_mul(ctx0, cur, it->second.signs);
+                }
+            }
+        }
 
         // apply lora for embedding tokens if needed
         for (const auto & lora : *loras) {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1493,10 +1493,19 @@ ggml_tensor * llm_graph_context::build_lora_mm(
     if (hadamard_rotations) {
         const auto it = hadamard_rotations->find(w);
         if (it != hadamard_rotations->end()) {
-            if (it->second.signs) {
-                cur_mm = ggml_mul(ctx0, cur_mm, it->second.signs);
+            const auto & t = it->second;
+            if (t.perm_rep > 1) {
+                // tiled [hd, nk, rep] -> grouped [hd, rep, nk] feature order
+                ggml_tensor * x = ggml_is_contiguous(cur_mm) ? cur_mm : ggml_cont(ctx0, cur_mm);
+                const int64_t ne1 = x->ne[1], ne2 = x->ne[2], ne3 = x->ne[3];
+                x = ggml_reshape_4d(ctx0, x, t.perm_hd, t.perm_nk, t.perm_rep, ne1*ne2*ne3);
+                x = ggml_cont(ctx0, ggml_permute(ctx0, x, 0, 2, 1, 3));
+                cur_mm = ggml_reshape_4d(ctx0, x, t.perm_hd*t.perm_nk*t.perm_rep, ne1, ne2, ne3);
             }
-            cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, it->second.rot);
+            if (t.signs) {
+                cur_mm = ggml_mul(ctx0, cur_mm, t.signs);
+            }
+            cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, t.rot);
         }
     }
 
@@ -1536,10 +1545,19 @@ ggml_tensor * llm_graph_context::build_lora_mm_id(
     if (hadamard_rotations) {
         const auto it = hadamard_rotations->find(w);
         if (it != hadamard_rotations->end()) {
-            if (it->second.signs) {
-                cur_mm = ggml_mul(ctx0, cur_mm, it->second.signs);
+            const auto & t = it->second;
+            if (t.perm_rep > 1) {
+                // tiled [hd, nk, rep] -> grouped [hd, rep, nk] feature order
+                ggml_tensor * x = ggml_is_contiguous(cur_mm) ? cur_mm : ggml_cont(ctx0, cur_mm);
+                const int64_t ne1 = x->ne[1], ne2 = x->ne[2], ne3 = x->ne[3];
+                x = ggml_reshape_4d(ctx0, x, t.perm_hd, t.perm_nk, t.perm_rep, ne1*ne2*ne3);
+                x = ggml_cont(ctx0, ggml_permute(ctx0, x, 0, 2, 1, 3));
+                cur_mm = ggml_reshape_4d(ctx0, x, t.perm_hd*t.perm_nk*t.perm_rep, ne1, ne2, ne3);
             }
-            cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, it->second.rot);
+            if (t.signs) {
+                cur_mm = ggml_mul(ctx0, cur_mm, t.signs);
+            }
+            cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, t.rot);
         }
     }
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1492,7 +1492,10 @@ ggml_tensor * llm_graph_context::build_lora_mm(
     if (hadamard_rotations) {
         const auto it = hadamard_rotations->find(w);
         if (it != hadamard_rotations->end()) {
-            cur_mm = llama_mul_mat_hadamard(ctx0, cur, it->second);
+            if (it->second.signs) {
+                cur_mm = ggml_mul(ctx0, cur_mm, it->second.signs);
+            }
+            cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, it->second.rot);
         }
     }
 
@@ -1532,7 +1535,10 @@ ggml_tensor * llm_graph_context::build_lora_mm_id(
     if (hadamard_rotations) {
         const auto it = hadamard_rotations->find(w);
         if (it != hadamard_rotations->end()) {
-            cur_mm = llama_mul_mat_hadamard(ctx0, cur, it->second);
+            if (it->second.signs) {
+                cur_mm = ggml_mul(ctx0, cur_mm, it->second.signs);
+            }
+            cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, it->second.rot);
         }
     }
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -17,9 +17,14 @@ struct ggml_cgraph;
 struct ggml_context;
 struct ggml_tensor;
 
-// Maps a folded model weight to the normalized Hadamard matrix required to
-// restore its activation-side basis immediately before the matmul.
-using llama_hadamard_rotations = std::unordered_map<const ggml_tensor *, ggml_tensor *>;
+// Maps a folded model weight to the activation-side transform applied
+// immediately before the matmul: optional sign flip, then the normalized
+// blockwise Hadamard rotation.
+struct llama_hadamard_transform {
+    ggml_tensor * rot;
+    ggml_tensor * signs; // nullptr for identity sign mode
+};
+using llama_hadamard_rotations = std::unordered_map<const ggml_tensor *, llama_hadamard_transform>;
 
 struct llama_cparams;
 struct llama_layer;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -762,6 +762,7 @@ struct llm_graph_params {
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
     const llama_hadamard_rotations * hadamard_rotations;
+    const llama_hadamard_rotations * hadamard_inverses;
 
     std::map<llama_seq_id, llama_sampler *> samplers;
 
@@ -1003,6 +1004,7 @@ struct llm_graph_context {
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
     const llama_hadamard_rotations * hadamard_rotations;
+    const llama_hadamard_rotations * hadamard_inverses;
 
     std::map<llama_seq_id, llama_sampler *> samplers;
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -23,6 +23,12 @@ struct ggml_tensor;
 struct llama_hadamard_transform {
     ggml_tensor * rot;
     ggml_tensor * signs; // nullptr for identity sign mode
+    // when perm_rep > 1 the activation arrives with its feature axis in tiled
+    // head order [hd, nk, rep] and must be permuted to the grouped order
+    // [hd, rep, nk] the fold was computed in, before signs and rotation
+    int64_t perm_hd  = 0;
+    int64_t perm_nk  = 0;
+    int64_t perm_rep = 0;
 };
 using llama_hadamard_rotations = std::unordered_map<const ggml_tensor *, llama_hadamard_transform>;
 

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -428,6 +428,7 @@ namespace GGUFMeta {
     }
 
     template bool llama_model_loader::get_key<bool>       (enum llm_kv kid, bool & result,        bool required);
+    template bool llama_model_loader::get_key<bool>       (const std::string & key, bool & result, bool required);
     template bool llama_model_loader::get_key<float>      (enum llm_kv kid, float & result,       bool required);
     template bool llama_model_loader::get_key<uint32_t>   (enum llm_kv kid, uint32_t & result,    bool required);
     template bool llama_model_loader::get_key<std::string>(enum llm_kv kid, std::string & result, bool required);

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -400,6 +400,7 @@ namespace GGUFMeta {
     }
 
     template bool llama_model_loader::get_arr<std::string>(const std::string & key, std::vector<std::string> & result, bool required);
+    template bool llama_model_loader::get_arr<int32_t>(const std::string & key, std::vector<int32_t> & result, bool required);
     template bool llama_model_loader::get_arr<std::vector<std::string>>(enum llm_kv kid, std::vector<std::string> & result, bool required);
     template bool llama_model_loader::get_arr<std::array<int32_t, 512>>(enum llm_kv kid, std::array<int32_t, 512> & result, bool required);
     template bool llama_model_loader::get_arr<std::vector<int32_t>>(enum llm_kv kid, std::vector<int32_t> & result, bool required);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1190,6 +1190,22 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
                 throw std::runtime_error(format("duplicate prism.hadamard weight: %s", weight_name.c_str()));
             }
         }
+
+        // tensors consumed by row lookup store latent rows and need the
+        // inverse transform applied to the lookup result instead
+        std::vector<std::string> inverse_names;
+        ml.get_arr("prism.hadamard.inverse_weight_names", inverse_names, false);
+        for (const auto & name : inverse_names) {
+            // the graph applies the inverse only to the token-embedding lookup; any
+            // other latent table would load and silently stay rotated
+            if (name != "token_embd.weight") {
+                throw std::runtime_error(format(
+                    "prism.hadamard: weight '%s' is not a verified inverse-after-lookup table", name.c_str()));
+            }
+            if (hadamard_weight_blocks.count(name) || !hadamard_inverse_blocks.emplace(name, block_size).second) {
+                throw std::runtime_error(format("duplicate prism.hadamard inverse weight: %s", name.c_str()));
+            }
+        }
     }
 
     // get general kv
@@ -1780,7 +1796,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         }
     }
 
-    if (!hadamard_weight_blocks.empty()) {
+    if (!hadamard_weight_blocks.empty() || !hadamard_inverse_blocks.empty()) {
         struct hadamard_rotation {
             uint32_t block_size;
             ggml_backend_buffer_type_t buft;
@@ -1790,7 +1806,12 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         std::vector<hadamard_rotation> rotations;
         std::map<std::pair<uint32_t, ggml_backend_buffer_type_t>, ggml_tensor *> sign_tensors;
 
-        for (const auto & entry : hadamard_weight_blocks) {
+        const std::pair<const std::unordered_map<std::string, uint32_t> *, llama_hadamard_rotations *> groups[] = {
+            { &hadamard_weight_blocks,  &hadamard_rotations },
+            { &hadamard_inverse_blocks, &hadamard_inverses  },
+        };
+        for (const auto & [blocks, target] : groups)
+        for (const auto & entry : *blocks) {
             const std::string & weight_name = entry.first;
             const uint32_t block_size = entry.second;
             const ggml_tensor * weight = get_tensor(weight_name.c_str());
@@ -1902,11 +1923,12 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
                 sign_tensor = st->second;
             }
 
-            hadamard_rotations.emplace(weight, llama_hadamard_transform { it->tensor, sign_tensor });
+            target->emplace(weight, llama_hadamard_transform { it->tensor, sign_tensor });
         }
 
-        LLAMA_LOG_INFO("%s: loaded %zu Hadamard-folded weight(s) using %zu rotation(s) and %zu sign vector(s)\n",
-                __func__, hadamard_rotations.size(), rotations.size(), sign_tensors.size());
+        LLAMA_LOG_INFO("%s: loaded %zu Hadamard-folded weight(s) (%zu inverse-lookup) using %zu rotation(s) and %zu sign vector(s)\n",
+                __func__, hadamard_rotations.size() + hadamard_inverses.size(), hadamard_inverses.size(),
+                rotations.size(), sign_tensors.size());
     }
 
     return true;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1158,12 +1158,15 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
 
         const auto is_foldable_weight = [](const std::string & name) {
             static const char * kinds[] = {
-                "attn_q", "attn_k", "attn_v", "attn_qkv", "attn_output",
+                "attn_q", "attn_k", "attn_v", "attn_qkv", "attn_gate", "attn_output",
                 "ffn_gate", "ffn_up", "ffn_down",
                 "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps", "ffn_gate_up_exps",
                 "ffn_gate_shexp", "ffn_up_shexp", "ffn_down_shexp",
                 "ssm_out",
             };
+            if (name == "output.weight") {
+                return true; // the output head is built through build_lora_mm in every arch
+            }
             if (name.compare(0, 4, "blk.") != 0) {
                 return false;
             }
@@ -1813,6 +1816,12 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             { &hadamard_weight_blocks,  &hadamard_rotations },
             { &hadamard_inverse_blocks, &hadamard_inverses  },
         };
+        // inverse (lookup-side) transforms must not inherit a host buffer
+        // type from a CPU-mapped table: the per-token transform would then
+        // ping-pong across the PCIe boundary. Prefer the buffer type the
+        // forward rotations live on (the GPU when layers are offloaded).
+        ggml_backend_buffer_type_t preferred_buft = nullptr;
+
         for (const auto & [blocks, target] : groups)
         for (const auto & entry : *blocks) {
             const std::string & weight_name = entry.first;
@@ -1830,7 +1839,12 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
                 throw std::runtime_error(format("prism.hadamard weight has no buffer: %s", weight_name.c_str()));
             }
 
-            const ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(weight->buffer);
+            ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(weight->buffer);
+            if (target == &hadamard_rotations) {
+                preferred_buft = buft;
+            } else if (preferred_buft) {
+                buft = preferred_buft;
+            }
             auto it = std::find_if(rotations.begin(), rotations.end(),
                     [block_size, buft](const hadamard_rotation & rotation) {
                         return rotation.block_size == block_size && rotation.buft == buft;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1137,6 +1137,8 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
             }
         }
 
+        ml.get_key("prism.hadamard.gdn_v_grouped", hadamard_gdn_v_grouped, false);
+
         // the activation-side transform is applied only by build_lora_mm/build_lora_mm_id;
         // refuse to load folded weights for architectures or tensor kinds that are not
         // verified to route every matmul through those helpers, rather than run wrong math
@@ -1160,6 +1162,7 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
                 "ffn_gate", "ffn_up", "ffn_down",
                 "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps", "ffn_gate_up_exps",
                 "ffn_gate_shexp", "ffn_up_shexp", "ffn_down_shexp",
+                "ssm_out",
             };
             if (name.compare(0, 4, "blk.") != 0) {
                 return false;
@@ -1923,7 +1926,18 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
                 sign_tensor = st->second;
             }
 
-            target->emplace(weight, llama_hadamard_transform { it->tensor, sign_tensor });
+            llama_hadamard_transform transform { it->tensor, sign_tensor };
+            if (hadamard_gdn_v_grouped && weight_name.find(".ssm_out.") != std::string::npos) {
+                const int64_t n_v = hparams.ssm_dt_rank;
+                const int64_t n_k = hparams.ssm_n_group;
+                if (n_k <= 0 || n_v <= 0 || n_v % n_k != 0 || weight->ne[0] % n_v != 0) {
+                    throw std::runtime_error(format("prism.hadamard: bad GDN head geometry for %s", weight_name.c_str()));
+                }
+                transform.perm_hd  = weight->ne[0] / n_v;
+                transform.perm_nk  = n_k;
+                transform.perm_rep = n_v / n_k;
+            }
+            target->emplace(weight, transform);
         }
 
         LLAMA_LOG_INFO("%s: loaded %zu Hadamard-folded weight(s) (%zu inverse-lookup) using %zu rotation(s) and %zu sign vector(s)\n",

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1106,11 +1106,35 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
         if (axis != "input-last-dimension") {
             throw std::runtime_error(format("unsupported prism.hadamard.axis: %s", axis.c_str()));
         }
-        if (sign_mode != "identity") {
+        if (sign_mode != "identity" && sign_mode != "explicit") {
             throw std::runtime_error(format("unsupported prism.hadamard.sign_mode: %s", sign_mode.c_str()));
         }
         if (weight_names.empty()) {
             throw std::runtime_error("prism.hadamard.weight_names is empty");
+        }
+
+        if (sign_mode == "explicit") {
+            std::vector<int32_t> sign_widths;
+            std::vector<int32_t> sign_values;
+            ml.get_arr("prism.hadamard.sign_widths", sign_widths);
+            ml.get_arr("prism.hadamard.sign_values", sign_values);
+            size_t off = 0;
+            for (const int32_t width : sign_widths) {
+                if (width <= 0 || (uint32_t) width % block_size != 0 || off + width > sign_values.size()) {
+                    throw std::runtime_error(format("invalid prism.hadamard sign width: %d", width));
+                }
+                auto & vec = hadamard_sign_data[width];
+                vec.assign(sign_values.begin() + off, sign_values.begin() + off + width);
+                for (const int32_t v : vec) {
+                    if (v != 1 && v != -1) {
+                        throw std::runtime_error("prism.hadamard sign values must be +/-1");
+                    }
+                }
+                off += width;
+            }
+            if (off != sign_values.size()) {
+                throw std::runtime_error("prism.hadamard.sign_values length mismatch");
+            }
         }
 
         // the activation-side transform is applied only by build_lora_mm/build_lora_mm_id;
@@ -1764,6 +1788,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         };
 
         std::vector<hadamard_rotation> rotations;
+        std::map<std::pair<uint32_t, ggml_backend_buffer_type_t>, ggml_tensor *> sign_tensors;
 
         for (const auto & entry : hadamard_weight_blocks) {
             const std::string & weight_name = entry.first;
@@ -1831,11 +1856,57 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
                 it = std::prev(rotations.end());
             }
 
-            hadamard_rotations.emplace(weight, it->tensor);
+            ggml_tensor * sign_tensor = nullptr;
+            if (!hadamard_sign_data.empty()) {
+                const uint32_t width = (uint32_t) weight->ne[0];
+                const auto sd = hadamard_sign_data.find(width);
+                if (sd == hadamard_sign_data.end()) {
+                    throw std::runtime_error(format(
+                        "prism.hadamard has no sign vector for width %u (%s)", width, weight_name.c_str()));
+                }
+                const auto key = std::make_pair(width, buft);
+                auto st = sign_tensors.find(key);
+                if (st == sign_tensors.end()) {
+                    ggml_init_params params = {
+                        /*.mem_size   =*/ ggml_tensor_overhead(),
+                        /*.mem_buffer =*/ NULL,
+                        /*.no_alloc   =*/ true,
+                    };
+                    ggml_context_ptr ctx { ggml_init(params) };
+                    if (!ctx) {
+                        throw std::runtime_error("failed to create Hadamard sign context");
+                    }
+
+                    ggml_tensor * signs = ggml_new_tensor_1d(ctx.get(), GGML_TYPE_F32, width);
+                    char sign_name[GGML_MAX_NAME];
+                    snprintf(sign_name, sizeof(sign_name), "prism.hadamard.signs.%u", width);
+                    ggml_set_name(signs, sign_name);
+
+                    ggml_backend_buffer_ptr buffer { ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft) };
+                    if (!buffer) {
+                        throw std::runtime_error(format("unable to allocate %s Hadamard sign buffer", ggml_backend_buft_name(buft)));
+                    }
+                    ggml_backend_buffer_set_usage(buffer.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+
+                    std::vector<float> data(width);
+                    for (uint32_t i = 0; i < width; ++i) {
+                        data[i] = (float) sd->second[i];
+                    }
+                    ggml_backend_tensor_set(signs, data.data(), 0, data.size() * sizeof(float));
+
+                    std::vector<ggml_backend_buffer_ptr> buffers;
+                    buffers.emplace_back(std::move(buffer));
+                    pimpl->ctxs_bufs.emplace_back(std::move(ctx), std::move(buffers));
+                    st = sign_tensors.emplace(key, signs).first;
+                }
+                sign_tensor = st->second;
+            }
+
+            hadamard_rotations.emplace(weight, llama_hadamard_transform { it->tensor, sign_tensor });
         }
 
-        LLAMA_LOG_INFO("%s: loaded %zu Hadamard-folded weight(s) using %zu persistent rotation(s)\n",
-                __func__, hadamard_rotations.size(), rotations.size());
+        LLAMA_LOG_INFO("%s: loaded %zu Hadamard-folded weight(s) using %zu rotation(s) and %zu sign vector(s)\n",
+                __func__, hadamard_rotations.size(), rotations.size(), sign_tensors.size());
     }
 
     return true;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -631,8 +631,10 @@ struct llama_model {
     // Hadamard-folded GGUF weights are matched with persistent model tensors
     // containing the activation-side transform.  The string map is populated
     // from GGUF metadata while loading hparams; the pointer map is populated
-    // after model buffers have been allocated.
+    // after model buffers have been allocated.  In explicit sign mode the
+    // per-width sign vectors come from GGUF metadata as well.
     std::unordered_map<std::string, uint32_t> hadamard_weight_blocks;
+    std::map<uint32_t, std::vector<int32_t>> hadamard_sign_data;
     llama_hadamard_rotations hadamard_rotations;
 
     // list of devices used in this model

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -636,6 +636,7 @@ struct llama_model {
     std::unordered_map<std::string, uint32_t> hadamard_weight_blocks;
     std::unordered_map<std::string, uint32_t> hadamard_inverse_blocks;
     std::map<uint32_t, std::vector<int32_t>> hadamard_sign_data;
+    bool hadamard_gdn_v_grouped = false;
     llama_hadamard_rotations hadamard_rotations;
     llama_hadamard_rotations hadamard_inverses;
 

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -634,8 +634,10 @@ struct llama_model {
     // after model buffers have been allocated.  In explicit sign mode the
     // per-width sign vectors come from GGUF metadata as well.
     std::unordered_map<std::string, uint32_t> hadamard_weight_blocks;
+    std::unordered_map<std::string, uint32_t> hadamard_inverse_blocks;
     std::map<uint32_t, std::vector<int32_t>> hadamard_sign_data;
     llama_hadamard_rotations hadamard_rotations;
+    llama_hadamard_rotations hadamard_inverses;
 
     // list of devices used in this model
     std::vector<llama_device> devices;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4404,6 +4404,71 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
+// sign flip + reshape + FWHT-hint matmul, the fusable Hadamard activation path
+struct test_fwht_signed : public test_case {
+    const int64_t blk;
+    const int64_t width;
+    const int64_t n_tokens;
+    const ggml_type type_x;
+
+    test_fwht_signed(int64_t blk = 1024, int64_t width = 5120, int64_t n_tokens = 7,
+                     ggml_type type_x = GGML_TYPE_F32)
+        : blk(blk), width(width), n_tokens(n_tokens), type_x(type_x) {}
+
+    std::string vars() override {
+        return VARS_TO_STR4(blk, width, n_tokens, type_x);
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "MUL_MAT_HADAMARD";
+    }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, blk, blk);
+        ggml_set_name(a, "a");
+        ggml_tensor * x = ggml_new_tensor_2d(ctx, type_x, width, n_tokens);
+        ggml_set_name(x, "x");
+        ggml_tensor * s = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, width);
+        ggml_set_name(s, "s");
+
+        ggml_tensor * cur = ggml_mul(ctx, x, s);
+        cur = ggml_reshape_2d(ctx, cur, blk, width / blk * n_tokens);
+        ggml_tensor * out = ggml_mul_mat(ctx, a, cur);
+        ggml_mul_mat_set_hint(out, GGML_HINT_SRC0_IS_HADAMARD);
+        ggml_set_name(out, "out");
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            if (strcmp(t->name, "a") == 0) {
+                const int64_t n_cols = t->ne[0];
+                const int64_t n_rows = ggml_nrows(t);
+                std::vector<float> data(n_cols * n_rows);
+                float scale = 1.0f / sqrtf((float)n_cols);
+                for (int64_t r = 0; r < n_rows; r++) {
+                    for (int64_t i = 0; i < n_cols; i++) {
+                        int pop = 0;
+                        int64_t val = r & i;
+                        while (val) { pop += (val & 1); val >>= 1; }
+                        data[r * n_cols + i] = (pop % 2 == 0) ? scale : -scale;
+                    }
+                }
+                ggml_backend_tensor_set(t, data.data(), 0, data.size() * sizeof(float));
+            } else if (strcmp(t->name, "s") == 0) {
+                std::vector<float> data(ggml_nelements(t));
+                for (size_t i = 0; i < data.size(); i++) {
+                    data[i] = (i % 3 == 0) ? -1.0f : 1.0f;
+                }
+                ggml_backend_tensor_set(t, data.data(), 0, data.size() * sizeof(float));
+            } else if (t->type == GGML_TYPE_F32 || t->type == GGML_TYPE_F16) {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+};
+
 static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
     std::random_device rd;
     std::default_random_engine rng(rd());
@@ -8831,6 +8896,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F16, 64, 1, 64));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F16, 128, 32, 128));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F16, 2048, 1, 2048));
+    test_cases.emplace_back(new test_fwht_signed(1024, 5120, 1));
+    test_cases.emplace_back(new test_fwht_signed(1024, 5120, 32));
+    test_cases.emplace_back(new test_fwht_signed(1024, 6144, 7, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_fwht_signed(1024, 17408, 3));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 32, 1, 32)); // too small (N<64)
 
 #if 0


### PR DESCRIPTION
Follow-up to #119, stacked on `hadamard-gguf-contract`. That PR shipped the identity-sign contract; this one adds what a real trained checkpoint needs.

## What

- **Explicit sign vectors.** `sign_mode "explicit"` carries per-width sign vectors in GGUF metadata (`prism.hadamard.sign_widths` plus a flattened `sign_values`). The loader materializes one F32 sign tensor per (width, buffer type) alongside the rotation, and the graph applies `x' = H (s * x)`: an elementwise sign flip, then the existing blockwise FWHT hint matmul. Identity mode is unchanged and unknown modes still refuse to load.
- **Inverse transform for latent embedding tables.** Tensors listed in `prism.hadamard.inverse_weight_names` store latent (rotated) rows; the graph restores the primal basis right after the token-embedding lookup, `h = s * (H z)`, so an embedding table can stay in the quantized latent format instead of a dequantized copy. The direct-embeddings input path is untouched.
- **Grouped-order linear-attention out_proj.** The converter's tiled V-head reorder permutes out_proj's input axis, which is the rotation axis of a folded latent; a post-fold column permutation breaks the blockwise correspondence and cannot be refolded without destroying the quantized codes. For folded out_proj tensors the converter now keeps the grouped V order and sets `prism.hadamard.gdn_v_grouped`; the runtime permutes the activation tiled-to-grouped (reshape, permute, cont) before the sign flip and rotation.
- Converter accepts schema v2 manifests (signs table, per-tensor roles), plus two missing template instantiations that only surface with the GNU linker.

## Why

Trained Hadamard checkpoints use seeded sign flips and rotate every projection including the embedding and output head. Without these three pieces the contract could only represent identity-sign folds on plain matmuls.

## Validation

- `test-backend-ops -o MUL_MAT_HADAMARD`: 14/14 on CUDA (SM90) and Metal against the CPU reference.
- End to end on a large hybrid-attention checkpoint packed with every projection folded (explicit signs, block 1024): logit KL divergence against the same model in unfolded F16 form lands at the measurement noise floor (mean KLD 3.7e-4, median 3.1e-4, same top-1 98.7%, mean ln PPL ratio -0.00005), i.e. the folded quantized pack is equivalent to the reference to the limit of the measurement.
- The activation-side transform stack measures at roughly 10% of GPU time on an H200 trace (FWHT 4.8%, sign multiplies 4.3%, permute copies about 2%), with obvious fusion headroom later.
