### PR TITLE
speculative: take the draft block layout from the draft model, not the CLI type

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -923,10 +923,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     int32_t     block_size    = 0;
     llama_token mask_token_id = 0;
 
-    // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout.
-    // Derived from the draft model itself, not from the requested type: reading a DSpark
-    // draft with the DFlash layout is off by one row and silently collapses acceptance
-    // (measured 0.27% against 51% on the same binary and weights).
+    // draft-dspark: the draft carries a Markov head. Comes from the model, not the
+    // requested type. The DSpark path also truncates on confidence, and for
+    // sample_from_anchor models it starts one row earlier.
     bool is_dspark = false;
 
     // dspark speculators
@@ -954,15 +953,14 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         target_layer_ids_n = llama_model_target_layer_ids_n(model_dft);
         GGML_ASSERT(target_layer_ids_n > 0 && "DFlash model has no target_layer_ids");
 
-        // These files declare general.architecture = dflash whichever lineage they come from,
-        // so the requested type cannot be trusted to pick the block layout. The Markov head is
-        // the on-disk marker of the DSpark lineage and is already loaded by then.
+        // Both lineages declare general.architecture = dflash, so the requested type cannot
+        // pick the draft path. The Markov head is the on-disk marker and is already loaded.
         is_dspark = llama_model_has_dspark_markov_head(model_dft);
         const bool type_says_dspark = (type == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK);
         if (type_says_dspark != is_dspark) {
-            LOG_WRN("%s: draft model carries %s, but --spec-type requested %s. Using the %s block "
-                    "layout that the model requires; the other layout reads drafts one row off and "
-                    "acceptance collapses to near zero.\n", __func__,
+            LOG_WRN("%s: draft model carries %s, but --spec-type requested %s. Using %s, which is "
+                    "what the model needs. The wrong path drops confidence truncation, and for "
+                    "sample_from_anchor models it also reads the drafts one row late.\n", __func__,
                     is_dspark ? "a DSpark Markov head" : "no DSpark Markov head",
                     common_speculative_type_to_str(type).c_str(),
                     is_dspark ? "DSpark" : "DFlash");
@@ -987,9 +985,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
-        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u, sample_from_anchor=%s, block_layout=%s\n", __func__,
+        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u, sample_from_anchor=%s, lineage=%s\n", __func__,
                 block_size, mask_token_id, target_layer_ids_n, sample_from_anchor ? "true" : "false",
-                is_dspark ? "dspark (anchor-first)" : "dflash (anchor at row 0)");
+                is_dspark ? "dspark" : "dflash");
 
         // DFlash input is [id_last, <mask> * (block_size-1)]: in-place denoising yields at most
         // block_size-1 draft tokens, anchor-first DSpark yields a full block_size draft tokens

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -923,8 +923,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     int32_t     block_size    = 0;
     llama_token mask_token_id = 0;
 
-    // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout
-    const bool is_dspark;
+    // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout.
+    // Derived from the draft model itself, not from the requested type: reading a DSpark
+    // draft with the DFlash layout is off by one row and silently collapses acceptance
+    // (measured 0.27% against 51% on the same binary and weights).
+    bool is_dspark = false;
 
     // dspark speculators
     bool sample_from_anchor = true;
@@ -939,7 +942,6 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             common_speculative_type type = COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH)
         : common_speculative_impl(type, n_seq)
         , params(params.draft)
-        , is_dspark(type == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK)
     {
         auto * ctx_tgt = this->params.ctx_tgt;
         auto * ctx_dft = this->params.ctx_dft;
@@ -951,6 +953,20 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         target_layer_ids   = llama_model_target_layer_ids  (model_dft);
         target_layer_ids_n = llama_model_target_layer_ids_n(model_dft);
         GGML_ASSERT(target_layer_ids_n > 0 && "DFlash model has no target_layer_ids");
+
+        // These files declare general.architecture = dflash whichever lineage they come from,
+        // so the requested type cannot be trusted to pick the block layout. The Markov head is
+        // the on-disk marker of the DSpark lineage and is already loaded by then.
+        is_dspark = llama_model_has_dspark_markov_head(model_dft);
+        const bool type_says_dspark = (type == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK);
+        if (type_says_dspark != is_dspark) {
+            LOG_WRN("%s: draft model carries %s, but --spec-type requested %s. Using the %s block "
+                    "layout that the model requires; the other layout reads drafts one row off and "
+                    "acceptance collapses to near zero.\n", __func__,
+                    is_dspark ? "a DSpark Markov head" : "no DSpark Markov head",
+                    common_speculative_type_to_str(type).c_str(),
+                    is_dspark ? "DSpark" : "DFlash");
+        }
 
         n_embd_tgt    = llama_model_n_embd(model_tgt);
         n_embd_dec    = llama_model_n_embd(model_dft);
@@ -971,8 +987,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
-        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u, sample_from_anchor=%s\n", __func__,
-                block_size, mask_token_id, target_layer_ids_n, sample_from_anchor ? "true" : "false");
+        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u, sample_from_anchor=%s, block_layout=%s\n", __func__,
+                block_size, mask_token_id, target_layer_ids_n, sample_from_anchor ? "true" : "false",
+                is_dspark ? "dspark (anchor-first)" : "dflash (anchor at row 0)");
 
         // DFlash input is [id_last, <mask> * (block_size-1)]: in-place denoising yields at most
         // block_size-1 draft tokens, anchor-first DSpark yields a full block_size draft tokens

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -124,9 +124,8 @@ LLAMA_API llama_context * llama_get_ctx_other(struct llama_context * ctx);
 LLAMA_API const int32_t * llama_model_target_layer_ids  (const struct llama_model * model);
 // returns the number of extracted layers from target model
 LLAMA_API uint32_t        llama_model_target_layer_ids_n(const struct llama_model * model);
-// returns true if the draft model carries a DSpark Markov head, which implies the
-// anchor-first block layout -- the file says general.architecture = dflash either way,
-// so this is the only reliable way to tell the two lineages apart
+// returns true if the draft model carries a DSpark Markov head. Both lineages declare
+// general.architecture = dflash, so this is how to tell them apart.
 LLAMA_API bool            llama_model_has_dspark_markov_head(const struct llama_model * model);
 
 // retrieves the whole token embedding matrix in F32 format (n_embd * n_vocab)

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -124,6 +124,10 @@ LLAMA_API llama_context * llama_get_ctx_other(struct llama_context * ctx);
 LLAMA_API const int32_t * llama_model_target_layer_ids  (const struct llama_model * model);
 // returns the number of extracted layers from target model
 LLAMA_API uint32_t        llama_model_target_layer_ids_n(const struct llama_model * model);
+// returns true if the draft model carries a DSpark Markov head, which implies the
+// anchor-first block layout -- the file says general.architecture = dflash either way,
+// so this is the only reliable way to tell the two lineages apart
+LLAMA_API bool            llama_model_has_dspark_markov_head(const struct llama_model * model);
 
 // retrieves the whole token embedding matrix in F32 format (n_embd * n_vocab)
 // returns total number of elements or 0 on error

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -3123,6 +3123,10 @@ uint32_t llama_model_target_layer_ids_n(const struct llama_model * model) {
     return (uint32_t) model->target_layer_ids.size();
 }
 
+bool llama_model_has_dspark_markov_head(const struct llama_model * model) {
+    return model->dspark_markov_w1 != nullptr;
+}
+
 uint32_t llama_model_get_tok_embd(const struct llama_model * model, float * out) {
     if (model->vocab.n_tokens() == 0 || model->tok_embd == nullptr) {
         return 0;

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -54,19 +54,8 @@ def test_with_and_without_draft():
 
 
 def test_draft_acceptance_floor():
-    # test_with_and_without_draft asserts that drafting happens (draft_n > 0), not that
-    # any draft is accepted. Those are different failures: a drafter can run at full
-    # speed, produce well-formed blocks, and have essentially every token rejected. That
-    # is what a wrong block layout or a mis-tapped feature looks like, and it is a pure
-    # slowdown with identical output, so every existing assertion here still passes.
-    #
-    # This drafter/target pair is deliberately mismatched (q4_0 stories15M drafting for
-    # the F16 MoE), so acceptance is low by nature: 15.0% and 17.4% measured on the two
-    # prompts below, deterministic at temperature 0. The floor sits well under that and
-    # well over a collapse -- the regression this guards against measured 0.27%.
-    #
-    # Scope: this covers the draft-simple path only. The block-layout-sensitive draft
-    # types need their own drafters and are not exercised by any tiny fixture model.
+    # The other tests check that drafting happens, not that drafts are accepted.
+    # This drafter/target pair is mismatched on purpose, so accept is only 15-17%.
     global server
     server.start()
     for prompt in [

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -53,6 +53,43 @@ def test_with_and_without_draft():
     assert tokens_no_draft == tokens_draft
 
 
+def test_draft_acceptance_floor():
+    # test_with_and_without_draft asserts that drafting happens (draft_n > 0), not that
+    # any draft is accepted. Those are different failures: a drafter can run at full
+    # speed, produce well-formed blocks, and have essentially every token rejected. That
+    # is what a wrong block layout or a mis-tapped feature looks like, and it is a pure
+    # slowdown with identical output, so every existing assertion here still passes.
+    #
+    # This drafter/target pair is deliberately mismatched (q4_0 stories15M drafting for
+    # the F16 MoE), so acceptance is low by nature: 15.0% and 17.4% measured on the two
+    # prompts below, deterministic at temperature 0. The floor sits well under that and
+    # well over a collapse -- the regression this guards against measured 0.27%.
+    #
+    # Scope: this covers the draft-simple path only. The block-layout-sensitive draft
+    # types need their own drafters and are not exercised by any tiny fixture model.
+    global server
+    server.start()
+    for prompt in [
+        "I believe the meaning of life is",
+        "Once upon a time there was a little girl who",
+    ]:
+        res = server.make_request("POST", "/completion", data={
+            "prompt": prompt,
+            "temperature": 0.0,
+            "top_k": 1,
+            "n_predict": 64,
+        })
+        assert res.status_code == 200
+        draft_n = res.body["timings"]["draft_n"]
+        draft_n_accepted = res.body["timings"]["draft_n_accepted"]
+        assert draft_n > 0, f"nothing was drafted for {prompt!r}"
+        accept_rate = draft_n_accepted / draft_n
+        assert accept_rate > 0.05, (
+            f"draft acceptance collapsed to {100 * accept_rate:.2f}% "
+            f"({draft_n_accepted}/{draft_n}) for {prompt!r}"
+        )
+
+
 def test_different_draft_min_draft_max():
     global server
     test_values = [


### PR DESCRIPTION
Lands the draft block-layout fix on `prism-v7`. Replaces #114, which was closed: it was broken as pushed and based on `prism-v6`, now marked do-not-build.

## The bug

A DSpark-lineage drafter reads its drafted block anchor-first, predicting from row 0. A DFlash drafter puts the anchor token in row 0 and predicts from row 1. Which convention gets used was decided solely by `--spec-type`, so running a DSpark drafter as `draft-dflash` took the DFlash branch and read every drafted token one row late.

Nothing errored. The drafter loaded, drafted at full speed, and produced tokens the target rejected almost every time. Because rejected drafts are simply discarded, the generated text stayed correct and only throughput moved, so this reads as "speculative decoding isn't helping much" rather than as a bug.

Measured on one RTX 4090, same binary, same weights, same prompts:

| block layout | acceptance | mean accepted len |
|---|---:|---:|
| dflash (as requested by the flag) | 0.272% | 1.01 |
| dspark (as the model requires) | 51.385% | 3.04 |

## The fix

Derive the layout from the draft model instead of the requested type.

These files declare `general.architecture = dflash` whichever lineage they come from, so the type can't identify them. The Markov head can: `src/models/dflash.cpp` defines DSpark as "DFlash + a semi-autoregressive Markov head and Confidence head" and creates that head as required whenever the tensor is present. It is already loaded by the time the speculator is constructed, so `dspark_markov_w1 != nullptr` is exactly the loader's own definition of the lineage, available for free.

- `llama_model_has_dspark_markov_head()` in `src/llama-ext.h` / `src/llama-model.cpp`
- `common/speculative.cpp` sets `is_dspark` from the model, and warns when `--spec-type` disagrees rather than silently honoring a request that cannot work
- the resolved layout is now in the init log next to `sample_from_anchor`, so the trap is visible without reading source

Validation: with the fix applied and the server launched with the **wrong** flag (`--spec-type draft-dflash`, the exact invocation that produced 0.272%), acceptance is 51.385% and the warning appears in the log. The failure mode is now unreachable through flag misuse rather than merely avoidable.

## Acceptance-floor test

`test_draft_acceptance_floor` in `tools/server/tests/unit/test_speculative.py`.

The existing tests assert that drafting happens (`draft_n > 0`), never that anything is accepted. Those are different failures, and a 185x acceptance collapse passed every test in the file. The fixture drafter is deliberately mismatched, so its acceptance is only 15.0% and 17.4% on the two prompts (deterministic at temperature 0); the floor sits at 5%, well under that and well over a collapse. I red-checked it by raising the floor above the measured rate and confirming it fails with a message naming the rate and counts.

It covers the `draft-simple` path only. No tiny fixture model exercises the block-layout-sensitive draft types, so this guards the general "acceptance quietly went to zero" class rather than this specific bug.

## Deliberately not included

Shifting the target layer tap by one (input-of-layer-k vs output-of-layer-k) is a real discrepancy against the private implementation and worth fixing on its own merits, but it is not this bug: measured, it moves acceptance by less than a point (50.456% vs 51.385%), inside run-to-run noise. I left it out rather than pass an unvalidated change alongside a proven one.

## Note on formatting

The repo's `.clang-format` disagrees with the committed style of `common/speculative.cpp`, including the constructor signature I only touched to remove one initializer. Running it would bury a four-line fix in unrelated reformatting, so the added lines follow the file's existing style instead.
