### PR TITLE
dflash: let the log-SNR input opt into graph reuse

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -75,6 +75,12 @@ void llm_graph_input_dspark_logsnr::set_input(const llama_ubatch * ubatch) {
     }
 }
 
+bool llm_graph_input_dspark_logsnr::can_reuse(const llm_graph_params & params) {
+    // v_feat is a function of n_tokens and n_seqs_unq, both already checked by
+    // llm_graph_params::allow_reuse, and of min/max_log_snr, fixed per model
+    return feat && feat->ne[1] == params.ubatch.n_tokens;
+}
+
 void llm_graph_input_embd::set_input(const llama_ubatch * ubatch) {
     if (ubatch->token) {
         const int64_t n_tokens = ubatch->n_tokens;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -152,6 +152,8 @@ public:
 
     void set_input(const llama_ubatch * ubatch) override;
 
+    bool can_reuse(const llm_graph_params & params) override;
+
     ggml_tensor * feat = nullptr; // F32 [128, n_tokens]
 
     std::vector<float> v_feat;


### PR DESCRIPTION
Cherry-picks bri-prism's 9ed9b9bf7, which landed on the #123 branch after the PR was merged and is not in prism-v7.

The merged #123 left the log-SNR graph input on the default can_reuse (false), so any conditioned drafter graph is rebuilt every ubatch. This lets the input opt into reuse: v_feat is a pure function of n_tokens and n_seqs_unq, both already compared by llm_graph_params::allow_reuse, plus min/max_log_snr which are fixed per model. Discussed and re-validated in https://github.com/PrismML-Eng/llama.cpp/pull/123#discussion_r3867603791 (acceptance 65.891%, mean length 3.58, unchanged).

Verified here: cherry-pick applies clean on prism-v7 (post #121), builds on macOS, Metal GATED_DELTA_NET suite passes.