### PR TITLE
hip: faster Q1_0, Q2_0 and PQ2_0 decode on AMD

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -938,8 +938,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         // Trigger when the full thread block covers all K blocks in a single loop iteration and few threads remain idle.
         const int  nwarps = calc_nwarps(type, c_ncols_dst, table_id);
         bool       use    = nwarps > 1 && blocks_per_row_x < nwarps * blocks_per_iter_1warp;
-        // on CDNA the small_k geometry (rows_per_block = nwarps) is several times slower than the default
-        // split-K geometry for these types, and with wave64 it triggers for every K < 4096 projection
+        // on CDNA the small_k geometry (rows_per_block = nwarps) is several times slower than the default split-K geometry for these types, and with wave64 it triggers for every K < 4096 projection
         if (GGML_CUDA_CC_IS_CDNA(cc) && (type == GGML_TYPE_Q1_0 || type == GGML_TYPE_Q2_0 || type == GGML_TYPE_PQ2_0)) {
             use = false;
         }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -938,6 +938,11 @@ static void mul_mat_vec_q_switch_ncols_dst(
         // Trigger when the full thread block covers all K blocks in a single loop iteration and few threads remain idle.
         const int  nwarps = calc_nwarps(type, c_ncols_dst, table_id);
         bool       use    = nwarps > 1 && blocks_per_row_x < nwarps * blocks_per_iter_1warp;
+        // on CDNA the small_k geometry (rows_per_block = nwarps) is several times slower than the default
+        // split-K geometry for these types, and with wave64 it triggers for every K < 4096 projection
+        if (GGML_CUDA_CC_IS_CDNA(cc) && (type == GGML_TYPE_Q1_0 || type == GGML_TYPE_Q2_0 || type == GGML_TYPE_PQ2_0)) {
+            use = false;
+        }
 
         constexpr std::array<ggml_type, 2> iq_slow_turing = {
             GGML_TYPE_IQ3_XXS,

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -679,8 +679,7 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
 }
 
 #if defined(GGML_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-// HIP implements __byte_perm as a software routine; these helpers use the hardware byte permute
-// (v_perm_b32) instead and produce the same bytes as the __byte_perm sequences below.
+// HIP implements __byte_perm as a software routine; these helpers use the hardware byte permute (v_perm_b32) instead and produce the same bytes as the __byte_perm sequences below.
 
 // 16 Q1_0 sign bits -> four ints holding weights 4j..4j+3 as int8 (+1 / -1) in bytes 0..3.
 // Per nibble n: spread = bit i of n -> LSB of byte i (n * 0x00204081 lands bit i at 7i+i = 8i, then mask);

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -678,6 +678,31 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     return d6 * sumf_d;
 }
 
+#if defined(GGML_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+// HIP implements __byte_perm as a software routine; these helpers use the hardware byte permute
+// (v_perm_b32) instead and produce the same bytes as the __byte_perm sequences below.
+
+// 16 Q1_0 sign bits -> four ints holding weights 4j..4j+3 as int8 (+1 / -1) in bytes 0..3.
+// Per nibble n: spread = bit i of n -> LSB of byte i (n * 0x00204081 lands bit i at 7i+i = 8i, then mask);
+// sel = 0x0D - spread_byte selects the constant 0xFF (sel 0x0D) or 0x00 (sel 0x0C) per byte; OR the spread back in.
+static __device__ __forceinline__ int q1_0_unpack4_hip(const uint32_t q, const int j) {
+    const uint32_t n      = (q >> (4 * j)) & 0x0Fu;
+    const uint32_t spread = (n * 0x00204081u) & 0x01010101u;
+    const uint32_t sel    = 0x0D0D0D0Du - spread;
+    return (int) (__builtin_amdgcn_perm(0u, 0u, sel) | spread);
+}
+
+// Four 2-bit codes (one byte) -> four int8 symbols {-1, 0, 1, 2}[code] in byte lanes.
+//   y: f0@0, f2@4 stay; f1 (bits 2-3) -> 8, f3 (bits 6-7) -> 12
+//   z: f0@0, f1@8 stay; f2 (bits 4-5) -> 16, f3 (bits 12-13) -> 24
+//   v_perm_b32 byte selectors 0..3 index the low-word LUT 0x020100FF = {0xFF, 0x00, 0x01, 0x02}
+static __device__ __forceinline__ int q2_0_symbols4_hip(const uint32_t b) {
+    const uint32_t y = (b & 0x33u) | ((b & 0xCCu) << 6);
+    const uint32_t z = (y & 0x0303u) | ((y & 0x3030u) << 12);
+    return (int) __builtin_amdgcn_perm(0x020100FFu, 0x020100FFu, z);
+}
+#endif  // defined(GGML_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+
 static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
 
@@ -703,6 +728,12 @@ static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
         const int u2 = get_int_b4(bq8_1_chunk->qs, j*4+2);
         const int u3 = get_int_b4(bq8_1_chunk->qs, j*4+3);
 
+#if defined(GGML_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+        const int v0 = q1_0_unpack4_hip((uint32_t) q, 0);
+        const int v1 = q1_0_unpack4_hip((uint32_t) q, 1);
+        const int v2 = q1_0_unpack4_hip((uint32_t) q, 2);
+        const int v3 = q1_0_unpack4_hip((uint32_t) q, 3);
+#else
         // unpack crumbs into nibble indices
         const int n0 = __byte_perm(0x11100100, 0x11100100, q >> 0); // [0, 1, 4, 5] [ 8,  9, 12, 13]
         const int n1 = __byte_perm(0x11100100, 0x11100100, q >> 2); // [2, 3, 6, 7] [10, 11, 14, 15]
@@ -716,6 +747,7 @@ static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
         const int v1 = __byte_perm(s0, s1, 0x7632);
         const int v2 = __byte_perm(s2, s3, 0x5410);
         const int v3 = __byte_perm(s2, s3, 0x7632);
+#endif
 
         sumi = ggml_cuda_dp4a(v0, u0, sumi);
         sumi = ggml_cuda_dp4a(v1, u1, sumi);
@@ -750,12 +782,17 @@ static __device__ __forceinline__ float vec_dot_q2_0_q8_1(
         const int u  = get_int_b4(bq8_1_chunk->qs, j*2+0);
         const int v  = get_int_b4(bq8_1_chunk->qs, j*2+1);
 
+#if defined(GGML_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+        const int qx = q2_0_symbols4_hip((uint32_t) q & 0xFFu);
+        const int qy = q2_0_symbols4_hip(((uint32_t) q >> 8) & 0xFFu);
+#else
         // unpack even and odd crumbs into byte values
         const int qe = __byte_perm(0x020100FF, 0x020100FF, q >> 0);
         const int qo = __byte_perm(0x020100FF, 0x020100FF, q >> 2);
         // unshuffle values
         const int qx = __byte_perm(qe, qo, 0x5140);
         const int qy = __byte_perm(qe, qo, 0x7362);
+#endif
 
         sumi = ggml_cuda_dp4a(u, qx, sumi);
         sumi = ggml_cuda_dp4a(v, qy, sumi);
@@ -785,10 +822,15 @@ static __device__ __forceinline__ float vec_dot_pq2_0_q8_1(
         const int u  = get_int_b4(bq8_1_chunk->qs, j*2+0);
         const int v  = get_int_b4(bq8_1_chunk->qs, j*2+1);
 
+#if defined(GGML_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+        const int qx = q2_0_symbols4_hip((uint32_t) q & 0xFFu);
+        const int qy = q2_0_symbols4_hip(((uint32_t) q >> 8) & 0xFFu);
+#else
         const int qe = __byte_perm(0x020100FF, 0x020100FF, q >> 0);
         const int qo = __byte_perm(0x020100FF, 0x020100FF, q >> 2);
         const int qx = __byte_perm(qe, qo, 0x5140);
         const int qy = __byte_perm(qe, qo, 0x7362);
+#endif
 
         sumi = ggml_cuda_dp4a(u, qx, sumi);
         sumi = ggml_cuda_dp4a(v, qy, sumi);


### PR DESCRIPTION
## What

HIP (AMD) speedups for the 1-bit and 2-bit weight kernels in `ggml-cuda`, guarded so CUDA and MUSA are untouched:

1. `vecdotq.cuh`: on HIP, `__byte_perm` is a software routine, so the Q1_0 sign unpack (ten permutes per 16 weights) and the Q2_0 / PQ2_0 symbol expansion (four permutes per 8 codes) were the dominant VALU cost of every decode dot product. Both now use the hardware byte permute (`v_perm_b32` via `__builtin_amdgcn_perm`): Q1_0 spreads each nibble's bits into byte lanes and selects the constant +1/-1 bytes; Q2_0 and PQ2_0 spread the four 2-bit codes into byte lanes and do one LUT lookup for `{-1, 0, 1, 2}`.
2. `mmvq.cu`: on CDNA, never pick the `small_k` MMVQ geometry (`rows_per_block = nwarps`) for Q1_0 / Q2_0 / PQ2_0. With wave64 it triggers for every K < 4096 projection and runs 2 to 4x slower per call than the default split-K geometry.

## Why

Profiling on an MI300X (ROCm 6.4.1) showed decode for these formats running at a few percent of HBM bandwidth with the mat-vec kernel bound on the software permutes, and the 4B model decoding slower than 8B because its K = 2560 projections fell into the `small_k` path.

## How verified

- `test-backend-ops -b ROCm0 -o MUL_MAT` and `-o MUL_MAT_ID`: all Q1_0 / Q2_0 / PQ2_0 cases pass before and after. The change is bit-exact by construction; the HIP helpers were also checked offline against the CUDA `__byte_perm` sequences for all 65536 16-bit inputs.
- Greedy 48-token generations on ROCm are byte-identical to the CPU backend for a 1-bit and a 2-bit model.
- `llama-bench` on MI300X, `-ngl 99 -fa 1`, 5 repetitions, interleaved A-B-A-B on this branch (`prism-v7`); prompt processing is unchanged because it goes through MMQ. Decode tokens/s:

| model | before (r1 / r2) | after (r1 / r2) | change |
|---|---|---|---|
| 4B Q1_0 | 112.7 / 112.2 | 323.7 / 320.0 | 2.9x |
| 8B Q1_0 | 88.6 / 73.2 | 269.7 / 269.3 | 3.0 to 3.7x |
| 27B Q1_0 | 31.5 / 31.5 | 96.9 / 97.5 | 3.1x |
| 8B PQ2_0 | 127.7 / 98.3 | 258.2 / 259.9 | 2.0 to 2.6x |
| 27B PQ2_0 | 48.6 / 48.7 | 91.7 / 91.7 | 1.9x |

No change on NVIDIA (the HIP branches are behind `GGML_USE_HIP` device-compile guards) and no change for other quant types (the `small_k` rule is type-scoped).
