### PR TITLE
metal: fix unused-parameter error when residency sets are unavailable

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -938,6 +938,8 @@ ggml_metal_rsets_t ggml_metal_rsets_init(ggml_metal_device_t dev) {
         // https://github.com/ggml-org/llama.cpp/issues/25937
         ggml_metal_dummy_work(dev);
     }
+#else
+    GGML_UNUSED(dev);
 #endif
 
     return res;


### PR DESCRIPTION
Found by the prism-v7 release dry run: the macOS release job builds on macos-14, whose SDK does not define GGML_METAL_HAS_RESIDENCY_SETS, so the dev parameter of ggml_metal_rsets_init is unused there and -Werror fails the build (run 33109344617, ggml-metal-device.m:881). The code is unchanged upstream, latent on newer SDKs; worth a small upstream PR too.

Fix: GGML_UNUSED(dev) in the #else of the existing guard.

Verified: Metal build clean locally with the release job's -Werror surviving a full LLAMA_FATAL_WARNINGS=ON build on both macOS/Metal and Linux/CUDA (the only other hit is a known GCC-12 stringop-overflow false positive in upstream ggml_cuda_try_fuse, which release CI does not enforce). A fresh release dry run should be dispatched after this merges.