### PR TITLE
readme: prism-v5 wording after the prism pointer moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > ## This branch is being retired
 >
-> You are on the **`prism` branch**, the release line behind all fork [releases](https://github.com/PrismML-Eng/llama.cpp/releases) up to and including this one. It is preserved as **`prism-v5`** going forward, and **this line is going away**: active development has moved to [`prism-v7`](https://github.com/PrismML-Eng/llama.cpp/tree/prism-v7), which is rebased onto current mainline llama.cpp. Do not use `prism-v6` (stale mid-migration snapshot).
+> You are on **`prism-v5`**, the frozen legacy line (formerly the `prism` branch, which now points at the current main line, developed as `prism-v7`). This line receives no further changes. Do not use `prism-v6` (stale mid-migration snapshot).
 >
 > **The final release of this line is [`prism-b9601-68faa14`](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b9601-68faa14).**
 >


### PR DESCRIPTION
The retirement notice on this line says 'you are on the prism branch, preserved as prism-v5'. Once prism points at the v7 line that sentence is stale on prism-v5 itself. Rewords it to name this branch as the frozen legacy line; the final-release link and limitations list are unchanged. Merge together with the pointer move.