### PR TITLE
llama: name the pre-rename PQ2_0 ftype instead of reporting unknown

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -157,6 +157,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_Q1_0          = 40, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q2_0          = 41, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_PQ2_0     = 141, // except 1d tensors (Prism group-128 Q2_0; matches published PQ2_0 ggufs)
+        LLAMA_FTYPE_MOSTLY_PQ2_0_LEGACY = 142, // pre-rename value for the same format, still found in published ggufs
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -40,6 +40,9 @@ const char * llama_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q1_0:      name = LLAMA_FTYPE_PREFIX "Q1_0"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_0:      name = LLAMA_FTYPE_PREFIX "Q2_0"; break;
         case LLAMA_FTYPE_MOSTLY_PQ2_0: name = LLAMA_FTYPE_PREFIX "PQ2_0 - 2.13 bpw (group 128)"; break;
+        // ggufs packed before the Q2_0_G128 -> PQ2_0 rename carry the old ftype value.
+        // They load and compute correctly; name it so it does not report as unknown.
+        case LLAMA_FTYPE_MOSTLY_PQ2_0_LEGACY: name = LLAMA_FTYPE_PREFIX "PQ2_0 - 2.13 bpw (group 128, legacy ftype)"; break;
         case LLAMA_FTYPE_MOSTLY_Q4_0:      name = LLAMA_FTYPE_PREFIX "Q4_0"; break;
         case LLAMA_FTYPE_MOSTLY_Q4_1:      name = LLAMA_FTYPE_PREFIX "Q4_1"; break;
         case LLAMA_FTYPE_MOSTLY_Q5_0:      name = LLAMA_FTYPE_PREFIX "Q5_0"; break;


### PR DESCRIPTION
Cosmetic, deferred from #121. Naming only.

## What

ggufs packed before the `Q2_0_G128` -> `PQ2_0` rename carry the old ftype value 142. The format did not change, only the enum did, so those files load and compute correctly but report:

```
print_info: file type   = unknown, may not work
```

which reads as a broken file. With this they report:

```
print_info: file type   = PQ2_0 - 2.13 bpw (group 128, legacy ftype)
```

No load path, no quantizer path, and no behaviour change. The new constant exists so the name switch has a case for the value.

## The confusing part

142 is also `GGML_TYPE_PQ2_0`, the tensor type id, which is current and correct. Two different enums with adjacent values. Only the ftype was renumbered, to 141, and only the ftype is affected here.

## Verified

On a published gguf that carries ftype 142, same file both ways:

| build | `file type =` |
|---|---|
| current prism-v7 | `unknown, may not work` |
| with this change | `PQ2_0 - 2.13 bpw (group 128, legacy ftype)` |

Output is identical either way, which is the point: these files were always fine, they just did not say so.
