### PR TITLE
hadamard: share the activation transform between folded weights that share an input

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1512,6 +1512,12 @@ ggml_tensor * llm_graph_context::build_lora_mm(
         const auto it = hadamard_rotations->find(w);
         if (it != hadamard_rotations->end()) {
             const auto & t = it->second;
+            // another folded weight on this same activation already built the transform
+            const auto memo_key = std::make_pair((const ggml_tensor *) cur, (const ggml_tensor *) t.rot);
+            const auto memo_it  = hadamard_memo.find(memo_key);
+            if (memo_it != hadamard_memo.end()) {
+                cur_mm = memo_it->second;
+            } else {
             if (t.perm_rep > 1) {
                 // tiled [hd, nk, rep] -> grouped [hd, rep, nk] feature order
                 ggml_tensor * x = ggml_is_contiguous(cur_mm) ? cur_mm : ggml_cont(ctx0, cur_mm);
@@ -1524,6 +1530,8 @@ ggml_tensor * llm_graph_context::build_lora_mm(
                 cur_mm = ggml_mul(ctx0, cur_mm, t.signs);
             }
             cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, t.rot);
+            hadamard_memo[memo_key] = cur_mm;
+            }
         }
     }
 
@@ -1564,6 +1572,12 @@ ggml_tensor * llm_graph_context::build_lora_mm_id(
         const auto it = hadamard_rotations->find(w);
         if (it != hadamard_rotations->end()) {
             const auto & t = it->second;
+            // another folded weight on this same activation already built the transform
+            const auto memo_key = std::make_pair((const ggml_tensor *) cur, (const ggml_tensor *) t.rot);
+            const auto memo_it  = hadamard_memo.find(memo_key);
+            if (memo_it != hadamard_memo.end()) {
+                cur_mm = memo_it->second;
+            } else {
             if (t.perm_rep > 1) {
                 // tiled [hd, nk, rep] -> grouped [hd, rep, nk] feature order
                 ggml_tensor * x = ggml_is_contiguous(cur_mm) ? cur_mm : ggml_cont(ctx0, cur_mm);
@@ -1576,6 +1590,8 @@ ggml_tensor * llm_graph_context::build_lora_mm_id(
                 cur_mm = ggml_mul(ctx0, cur_mm, t.signs);
             }
             cur_mm = llama_mul_mat_hadamard(ctx0, cur_mm, t.rot);
+            hadamard_memo[memo_key] = cur_mm;
+            }
         }
     }
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -1078,11 +1078,8 @@ struct llm_graph_context {
     const llama_hadamard_rotations * hadamard_rotations;
     const llama_hadamard_rotations * hadamard_inverses;
 
-    // Folded weights that share an activation also share its transform: gate and up
-    // take the same post-norm tensor, as do qkv and its gate, and q/k/v. ggml does no
-    // common-subexpression elimination, so without this each one builds its own
-    // identical sign-multiply and FWHT. Keyed on the input and the rotation, since a
-    // shared transform needs both to match. Lives for one graph build.
+    // Transforms shared by folded weights on the same activation. Key is (input, rotation);
+    // both must match. Valid for one graph build only.
     mutable std::map<std::pair<const ggml_tensor *, const ggml_tensor *>, ggml_tensor *> hadamard_memo;
 
     std::map<llama_seq_id, llama_sampler *> samplers;

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -1078,6 +1078,13 @@ struct llm_graph_context {
     const llama_hadamard_rotations * hadamard_rotations;
     const llama_hadamard_rotations * hadamard_inverses;
 
+    // Folded weights that share an activation also share its transform: gate and up
+    // take the same post-norm tensor, as do qkv and its gate, and q/k/v. ggml does no
+    // common-subexpression elimination, so without this each one builds its own
+    // identical sign-multiply and FWHT. Keyed on the input and the rotation, since a
+    // shared transform needs both to match. Lives for one graph build.
+    mutable std::map<std::pair<const ggml_tensor *, const ggml_tensor *>, ggml_tensor *> hadamard_memo;
+
     std::map<llama_seq_id, llama_sampler *> samplers;
 
     const llm_graph_cb & cb_func;


### PR DESCRIPTION
Free speedup: folded weights that share an activation were each building their own copy of the same transform.

## The redundancy

ggml does no common-subexpression elimination, so `build_lora_mm` inserting a sign-multiply and an FWHT per folded weight means the work runs once per *weight* rather than once per *activation*. Three groups share an input on this architecture:

| group | site | redundant transforms |
|---|---|---|
| `ffn_gate` + `ffn_up` | `build_ffn`, `LLM_FFN_PAR`, both take `cur` | 64 |
| `attn_qkv` + `attn_gate` | `qwen35.cpp:237,241`, both take `input` | 48 |
| `attn_q` + `attn_k` + `attn_v` | `qwen35.cpp:270,282,285`, all take `cur` | 32 |

144 of the 401 folded weights were recomputing a transform that already existed, so **36% of the FWHT calls per token were duplicates**.

## The change

`build_lora_mm` and `build_lora_mm_id` memoize on `(input, rotation)`. Both have to match for a transform to be shared: same input tensor, same rotation, which also implies the same width and therefore the same sign vector. The map lives for one graph build. 2 files, +23 lines.

## Measured

M5, Metal, a folded low-bit checkpoint. Three interleaved pairs on a warm machine, since the first runs drift upward with warmup:

| | baseline | this branch | delta |
|---|---|---|---|
| pp512 | 358.29 | 370.74 | **+3.5%** |
| tg128 | 23.20 | 23.91 | **+3.1%** |

Spread was at most 1.1 on pp512 and 0.11 on tg128, so the gap sits well outside the noise. Greedy output is unchanged byte for byte on the same prompt.

The magnitude matches the prediction, which is the reassuring part: the transform stack was about 10% of traced GPU time and removing 36% of it should be worth roughly 3.5%.

## Notes

Metal only so far. The change is backend-agnostic, it removes graph nodes rather than touching any kernel, so CUDA should see the same or more given it has more launch overhead to save at batch-1. Worth one CUDA run to confirm.

Architectures whose folded weights do not share inputs simply never hit the memo and are unaffected.
