### PR TITLE
ggml-cpu: restore the src1 guard on the F16 Hadamard matmul path

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -5,6 +5,7 @@
 #include "ggml-backend.h"
 #include "traits.h"
 #include "ggml-cpu-impl.h"
+#include "ggml-cpu.h"
 #include "ggml-impl.h"
 #include "quants.h"
 #include "ggml-threading.h"
@@ -1340,7 +1341,11 @@ UseGgmlGemm1:;
         const size_t nbw3 = nbw2*ne12;
 
         assert(params->wsize >= ne13*nbw3);
-        GGML_ASSERT(src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16);
+        // an F16 src1 is converted straight to float below, so it is only valid when the
+        // wdata rows are floats. A quantized vec_dot_type would size them at about one
+        // byte per element and the conversion would run off the end of the buffer.
+        GGML_ASSERT(src1->type == GGML_TYPE_F32 ||
+                    (src1->type == GGML_TYPE_F16 && vec_dot_type == GGML_TYPE_F32));
 
     #if 0
         for (int64_t i13 = 0; i13 < ne13; ++i13) {
@@ -1366,11 +1371,7 @@ UseGgmlGemm1:;
                     if (src1->type == GGML_TYPE_F32) {
                         from_float((const float *) src1_block, dst_block, n_block);
                     } else {
-                        const ggml_fp16_t * src_f16 = (const ggml_fp16_t *) src1_block;
-                        float * dst_f32 = (float *) dst_block;
-                        for (int64_t i = 0; i < n_block; ++i) {
-                            dst_f32[i] = GGML_CPU_FP16_TO_FP32(src_f16[i]);
-                        }
+                        ggml_cpu_fp16_to_fp32((const ggml_fp16_t *) src1_block, (float *) dst_block, n_block);
                     }
                 }
             }

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -1341,9 +1341,7 @@ UseGgmlGemm1:;
         const size_t nbw3 = nbw2*ne12;
 
         assert(params->wsize >= ne13*nbw3);
-        // an F16 src1 is converted straight to float below, so it is only valid when the
-        // wdata rows are floats. A quantized vec_dot_type would size them at about one
-        // byte per element and the conversion would run off the end of the buffer.
+        // F16 src1 converts straight to float, so wdata rows must be floats; a quantized vec_dot_type would overrun the buffer
         GGML_ASSERT(src1->type == GGML_TYPE_F32 ||
                     (src1->type == GGML_TYPE_F16 && vec_dot_type == GGML_TYPE_F32));
 


### PR DESCRIPTION
## What

Two follow-ups to the F16 `src1` support on the Hadamard-hinted matmul path in
`ggml_compute_forward_mul_mat`. One restores an assertion, one replaces a hand-rolled loop with
the vectorised routine that already exists for it.

## Why

**The assertion.** The conversion block the F16 branch lives in is entered whenever
`src1->type != vec_dot_type`, and that branch writes plain floats into `wdata`. That is only
valid when the `wdata` rows are floats. With a quantized `src0` the `vec_dot_type` is
Q8_0/Q8_1/Q8_K, whose rows are about one byte per element (34 bytes per 32 for Q8_0), so writing
four bytes per element would run roughly 3.8x past the end of the buffer.

Nothing reaches that today. `supports_op` admits an F16 `src1` only when `src0` and `dst` are
both F32, so the scheduler never routes the bad combination to the CPU backend. The point is
narrower: the assertion here used to be `src1->type == GGML_TYPE_F32` and would have caught it,
and widening it to admit F16 unconditionally left the invariant undefended for any caller that
reaches `forward_mul_mat` without going through `supports_op`. This asserts what the code
actually handles.

**The loop.** `ggml_cpu_fp16_to_fp32` is declared in `ggml-cpu.h` and defined further down this
same file with F16C and AVX512F paths, so the branch can call it instead of converting element by
element. That needs the header included, since the definition sits below the call site.

## Testing

`test-backend-ops` on CPU:

- `MUL_MAT` 1249/1249
- `MUL_MAT_HADAMARD` 18/18, including the four `type_b=f16` cases and the `type_x=f16` FWHT case

Worth stating plainly: the suite passes identically before and after, which is the expected
result. The converter swap is behaviour-preserving, and the assertion defends a path no test
drives, because `supports_op` refuses a quantized `src0` with an F16 `src1` and the harness skips
it as unsupported. So these tests show nothing is broken; they would not have caught the widened
assertion in the first place. Testing that invariant properly needs a direct call into
`forward_mul_mat` outside the scheduler, which is a larger change than this.

No performance claim. The F16 branch only runs for Hadamard-hinted F32 matmuls, so it is off the
hot path for ordinary decode, and I did not measure it.

## Notes

`clang-format` is not applied. Adding an include makes it alphabetize and reflow the whole include
block, which this file's order does not follow, so the formatting change would be larger and less
reviewable than the fix. The new include is grouped with the other `ggml-cpu` headers.

The same two issues exist in the corresponding upstream PR, ggml-org/llama.cpp#27779, which is
still open. If that lands as-is, upstream inherits both.
