### PR TITLE
tests: build the two PTQ1_0 verification tests added in #148

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -312,6 +312,8 @@ if (NOT GGML_BACKEND_DL)
     # these tests use the backends directly and cannot be built with dynamic loading
     llama_build_and_test(test-barrier.cpp)
     llama_build_and_test(test-quantize-fns.cpp)
+llama_build_and_test(test-ptq1_0-element-map.cpp)
+llama_build_and_test(test-ptq1_0-cuda-dot.cpp)
     llama_build_and_test(test-quantize-perf.cpp)
     llama_build_and_test(test-rope.cpp)
     llama_build_and_test(test-col2im-1d.cpp)


### PR DESCRIPTION
`tests/test-ptq1_0-element-map.cpp` and `tests/test-ptq1_0-cuda-dot.cpp` landed in #148 but were never added to `tests/CMakeLists.txt`, so CI has never built or run them. This registers both with `llama_build_and_test`.

Built and run on macOS (Metal build): element map checks 2,560,000 positions across 20,000 random blocks with 0 mismatches; the host-stubbed CUDA dot test reports 20,000 exact integer comparisons, 0 mismatches, worst error 2.4e-08 of the term magnitude.