### PR TITLE
metal, vulkan: FWHT kernels for wide block widths (to prism)

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -148,7 +148,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_fwht     
 // FWHT block widths with dedicated Metal kernels; the Hadamard matmul hint
 // falls back to a plain mul_mat for other widths, which has no F16-input pipeline.
 static inline bool ggml_metal_fwht_supported_size(int64_t n) {
-    return n == 64 || n == 128 || n == 256 || n == 512 || n == 1024 || n == 2048;
+    return n == 64 || n == 128 || n == 256 || n == 512 || n == 1024 || n == 2048 || n == 4096 || n == 8192;
 }
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k             (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_merge       (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -1204,6 +1204,11 @@ typedef struct {
     int32_t  len;
 } ggml_metal_kargs_argsort_merge;
 
+// Block widths at or above this run the threadgroup-staged FWHT kernel: the
+// register-resident one keeps N/32 values per thread, which stops fitting here.
+#define GGML_METAL_FWHT_TG_MIN_N 4096
+#define GGML_METAL_FWHT_TG_NT    256
+
 typedef struct {
     int32_t nrows;
 } ggml_metal_kargs_fwht;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2444,6 +2444,13 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
     const int th_max = ggml_metal_pipeline_max_theads_per_threadgroup(pipeline);
     const int simd_size = 32;
 
+    if (n >= GGML_METAL_FWHT_TG_MIN_N) {
+        GGML_ASSERT(th_max >= GGML_METAL_FWHT_TG_NT);
+        ggml_metal_encoder_dispatch_threadgroups(enc, nrows, 1, 1, GGML_METAL_FWHT_TG_NT, 1, 1);
+
+        return 1;
+    }
+
     int sg_per_tg = 2;
     sg_per_tg = std::min(sg_per_tg, th_max/simd_size);
     sg_per_tg = std::max(sg_per_tg, 1);

--- a/ggml/src/ggml-metal/kernels/misc.metal
+++ b/ggml/src/ggml-metal/kernels/misc.metal
@@ -429,6 +429,79 @@ kernel void kernel_fwht(
     }
 }
 
+// Wide blocks: one row per threadgroup instead of per simdgroup, so each thread
+// keeps N/NT values rather than N/32. Butterflies below the simdgroup width still
+// shuffle; those up to NT go through threadgroup memory; the rest stay in registers.
+template<int N, int NT, typename src_t>
+kernel void kernel_fwht_tg(
+        constant ggml_metal_kargs_fwht & args,
+        device const src_t * src,
+        device float * dst,
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort3  ntg[[threads_per_threadgroup]]) {
+
+    constexpr int NW = N_SIMDWIDTH;
+    constexpr int NE = N / NT;
+
+    threadgroup float shmem[N];
+
+    const float scale = 1.0f / sqrt((float) N);
+
+    const int64_t r = tgpig.x;
+    if (r >= args.nrows) {
+        return;
+    }
+
+    src += r * N;
+    dst += r * N;
+
+    const int tid = sgitg * NW + tiisg;
+
+    float reg[NE];
+    for (int i = 0; i < NE; i++) {
+        reg[i] = float(src[i*NT + tid])*scale;
+    }
+
+    for (int i = 1; i < NW; i *= 2) {
+        for (int j = 0; j < NE; j++) {
+            const float val  = reg[j];
+            const float val2 = simd_shuffle_xor(val, i);
+            reg[j] = (tid & i) == 0 ? val2 + val : val2 - val;
+        }
+    }
+
+    for (int i = NW; i < NT; i *= 2) {
+        for (int j = 0; j < NE; j++) {
+            shmem[j*NT + tid] = reg[j];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int j = 0; j < NE; j++) {
+            const float val  = reg[j];
+            const float val2 = shmem[j*NT + (tid ^ i)];
+            reg[j] = (tid & i) == 0 ? val2 + val : val2 - val;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (int i = NT; i < N; i *= 2) {
+        const int step = i / NT;
+        for (int j = 0; j < NE; j += (2 * step)) {
+            for (int k = 0; k < step; k++) {
+                const float x = reg[j + k ];
+                const float y = reg[j + k + step];
+                reg[j + k]        = x + y;
+                reg[j + k + step] = x - y;
+            }
+        }
+    }
+
+    for (int i = 0; i < NE; i++) {
+        dst[i*NT + tid] = reg[i];
+    }
+}
+
 typedef decltype(kernel_fwht<64, float>) kernel_fwht_f32_t;
 typedef decltype(kernel_fwht<64, half>)  kernel_fwht_f16_t;
 
@@ -444,6 +517,10 @@ template [[host_name("kernel_fwht_f16_256")]]  kernel kernel_fwht_f16_t kernel_f
 template [[host_name("kernel_fwht_f16_512")]]  kernel kernel_fwht_f16_t kernel_fwht<512, half>;
 template [[host_name("kernel_fwht_f16_1024")]] kernel kernel_fwht_f16_t kernel_fwht<1024, half>;
 template [[host_name("kernel_fwht_f16_2048")]] kernel kernel_fwht_f16_t kernel_fwht<2048, half>;
+template [[host_name("kernel_fwht_f32_4096")]] kernel kernel_fwht_f32_t kernel_fwht_tg<4096, GGML_METAL_FWHT_TG_NT, float>;
+template [[host_name("kernel_fwht_f32_8192")]] kernel kernel_fwht_f32_t kernel_fwht_tg<8192, GGML_METAL_FWHT_TG_NT, float>;
+template [[host_name("kernel_fwht_f16_4096")]] kernel kernel_fwht_f16_t kernel_fwht_tg<4096, GGML_METAL_FWHT_TG_NT, half>;
+template [[host_name("kernel_fwht_f16_8192")]] kernel kernel_fwht_f16_t kernel_fwht_tg<8192, GGML_METAL_FWHT_TG_NT, half>;
 
 kernel void kernel_dsv4_hc_comb_f32(
         constant ggml_metal_kargs_dsv4_hc_comb & args,

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -768,12 +768,15 @@ static constexpr std::initializer_list<std::array<int, 3>> rms_norm_mul_rope_vie
 };
 
 
-// FWHT block widths with a dedicated Vulkan pipeline. Widths above
-// GGML_VK_FWHT_MAX_SUBGROUP_N would keep n/subgroup_size values per invocation in
-// the register-resident shader, so those stage through shared memory instead.
-static constexpr uint32_t GGML_VK_FWHT_NUM_SIZES      = 8;
-static constexpr uint32_t GGML_VK_FWHT_MAX_SUBGROUP_N = 2048;
-static constexpr uint32_t GGML_VK_FWHT_ROWS           = 4;
+// FWHT block widths with a dedicated Vulkan pipeline. The subgroup shader pins its
+// block to the subgroup width, so it keeps n/subgroup_size values per invocation;
+// widths that push that past GGML_VK_FWHT_MAX_SUBGROUP_EL_W stage through shared
+// memory instead. The cutoff has to key on that ratio and not on n alone, because a
+// device reporting a narrow subgroup reaches the same register wall at a smaller n.
+static constexpr uint32_t GGML_VK_FWHT_NUM_SIZES         = 8;
+static constexpr uint32_t GGML_VK_FWHT_MAX_SUBGROUP_N    = 2048;
+static constexpr uint32_t GGML_VK_FWHT_MAX_SUBGROUP_EL_W = 64;
+static constexpr uint32_t GGML_VK_FWHT_ROWS              = 4;
 
 struct vk_device_struct {
     std::recursive_mutex mutex;
@@ -5791,8 +5794,9 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     if (can_use_fwht) {
         const bool use_subgroup = device->subgroup_basic && device->subgroup_shuffle;
         int idx = 0;
+        const uint32_t sg = std::max(device->subgroup_size, 1u);
         for (uint32_t n : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
-            const bool wide = n > GGML_VK_FWHT_MAX_SUBGROUP_N;
+            const bool wide = n > GGML_VK_FWHT_MAX_SUBGROUP_N || n / sg > GGML_VK_FWHT_MAX_SUBGROUP_EL_W;
             if (use_subgroup && !wide) {
                 if (device->subgroup_size <= n) {
                     ggml_vk_create_pipeline(device, device->pipeline_fwht_f32[idx], "fwht_f32", fwht_f32_len, fwht_f32_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { device->subgroup_size, n, GGML_VK_FWHT_ROWS }, 1, true, true, device->subgroup_size);
@@ -5804,7 +5808,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
                 }
             } else {
                 // wide blocks trade rows per workgroup for a smaller register block
-                const uint32_t block_size = wide ? std::min(n, 256u) : std::min(device->subgroup_size, n);
+                const uint32_t block_size = wide ? std::min(n, 256u) : std::min(sg, n);
                 const uint32_t rows       = wide ? 1u : GGML_VK_FWHT_ROWS;
                 if ((uint64_t)rows * n * sizeof(float) <= device->properties.limits.maxComputeSharedMemorySize &&
                     block_size * rows <= device->properties.limits.maxComputeWorkGroupInvocations) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -768,6 +768,13 @@ static constexpr std::initializer_list<std::array<int, 3>> rms_norm_mul_rope_vie
 };
 
 
+// FWHT block widths with a dedicated Vulkan pipeline. Widths above
+// GGML_VK_FWHT_MAX_SUBGROUP_N would keep n/subgroup_size values per invocation in
+// the register-resident shader, so those stage through shared memory instead.
+static constexpr uint32_t GGML_VK_FWHT_NUM_SIZES      = 8;
+static constexpr uint32_t GGML_VK_FWHT_MAX_SUBGROUP_N = 2048;
+static constexpr uint32_t GGML_VK_FWHT_ROWS           = 4;
+
 struct vk_device_struct {
     std::recursive_mutex mutex;
     mutable std::shared_mutex pinned_memory_mutex;
@@ -1042,8 +1049,10 @@ struct vk_device_struct {
     vk_pipeline pipeline_argsort_large_f32[num_argsort_pipelines];
     vk_pipeline pipeline_topk_f32[num_topk_pipelines];
     vk_pipeline pipeline_sum_rows_f32;
-    vk_pipeline pipeline_fwht_f32[4];
-    vk_pipeline pipeline_fwht_f16[4];
+    vk_pipeline pipeline_fwht_f32[GGML_VK_FWHT_NUM_SIZES];
+    vk_pipeline pipeline_fwht_f16[GGML_VK_FWHT_NUM_SIZES];
+    // rows a workgroup covers, chosen per width when the pipeline is built
+    uint32_t fwht_rows_per_wg[GGML_VK_FWHT_NUM_SIZES] = {};
     vk_pipeline pipeline_cumsum_f32;
     vk_pipeline pipeline_cumsum_small_f32;
     vk_pipeline pipeline_cumsum_multipass1_f32;
@@ -5779,25 +5788,32 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     // Intel Windows driver in range [32.0.101.8509, 32.0.101.8860) will crash when using fwht kernels so we gate that here
     const bool can_use_fwht = device->driver_id != vk::DriverId::eIntelProprietaryWindows ||
         !ggml_vk_intel_windows_driver_in_range(device->properties.driverVersion, 101, 8509, 101, 8860);
-    if (can_use_fwht && device->subgroup_basic && device->subgroup_shuffle) {
+    if (can_use_fwht) {
+        const bool use_subgroup = device->subgroup_basic && device->subgroup_shuffle;
         int idx = 0;
-        for (uint32_t n : {64, 128, 256, 512}) {
-            if (device->subgroup_size <= n) {
-            ggml_vk_create_pipeline(device, device->pipeline_fwht_f32[idx], "fwht_f32", fwht_f32_len, fwht_f32_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { device->subgroup_size, n }, 1, true, true, device->subgroup_size);
-            // the f16 shader needs shader-float16; a null pipeline makes ggml_vk_can_use_fwht fall back
-            if (device->fp16) {
-                ggml_vk_create_pipeline(device, device->pipeline_fwht_f16[idx], "fwht_f16", fwht_f16_len, fwht_f16_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { device->subgroup_size, n }, 1, true, true, device->subgroup_size);
-            }
-            }
-            ++idx;
-        }
-    } else if (can_use_fwht) {
-        int idx = 0;
-        for (uint32_t n : {64, 128, 256, 512}) {
-            const uint32_t block_size = std::min(device->subgroup_size, n);
-            ggml_vk_create_pipeline(device, device->pipeline_fwht_f32[idx], "fwht_shmem_f32", fwht_shmem_f32_len, fwht_shmem_f32_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { block_size, n }, 1);
-            if (device->fp16) {
-                ggml_vk_create_pipeline(device, device->pipeline_fwht_f16[idx], "fwht_shmem_f16", fwht_shmem_f16_len, fwht_shmem_f16_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { block_size, n }, 1);
+        for (uint32_t n : {64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
+            const bool wide = n > GGML_VK_FWHT_MAX_SUBGROUP_N;
+            if (use_subgroup && !wide) {
+                if (device->subgroup_size <= n) {
+                    ggml_vk_create_pipeline(device, device->pipeline_fwht_f32[idx], "fwht_f32", fwht_f32_len, fwht_f32_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { device->subgroup_size, n, GGML_VK_FWHT_ROWS }, 1, true, true, device->subgroup_size);
+                    // the f16 shader needs shader-float16; a null pipeline makes ggml_vk_can_use_fwht fall back
+                    if (device->fp16) {
+                        ggml_vk_create_pipeline(device, device->pipeline_fwht_f16[idx], "fwht_f16", fwht_f16_len, fwht_f16_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { device->subgroup_size, n, GGML_VK_FWHT_ROWS }, 1, true, true, device->subgroup_size);
+                    }
+                    device->fwht_rows_per_wg[idx] = GGML_VK_FWHT_ROWS;
+                }
+            } else {
+                // wide blocks trade rows per workgroup for a smaller register block
+                const uint32_t block_size = wide ? std::min(n, 256u) : std::min(device->subgroup_size, n);
+                const uint32_t rows       = wide ? 1u : GGML_VK_FWHT_ROWS;
+                if ((uint64_t)rows * n * sizeof(float) <= device->properties.limits.maxComputeSharedMemorySize &&
+                    block_size * rows <= device->properties.limits.maxComputeWorkGroupInvocations) {
+                    ggml_vk_create_pipeline(device, device->pipeline_fwht_f32[idx], "fwht_shmem_f32", fwht_shmem_f32_len, fwht_shmem_f32_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { block_size, n, rows }, 1);
+                    if (device->fp16) {
+                        ggml_vk_create_pipeline(device, device->pipeline_fwht_f16[idx], "fwht_shmem_f16", fwht_shmem_f16_len, fwht_shmem_f16_data, "main", 2, sizeof(vk_op_fwht_push_constants), {1, 1, 1}, { block_size, n, rows }, 1);
+                    }
+                    device->fwht_rows_per_wg[idx] = rows;
+                }
             }
             ++idx;
         }
@@ -9986,12 +10002,17 @@ static void ggml_vk_mul_mat_vec_nc_f16_f32(ggml_backend_vk_context * ctx, vk_con
         }, pc, { (uint32_t)ne03, (uint32_t)ne01, (uint32_t)ne12 });
 }
 
+// keep in sync with the width list in ggml_vk_load_shaders and GGML_VK_FWHT_NUM_SIZES
 static int ggml_vk_fwht_pipeline_idx(int64_t n) {
     switch (n) {
         case 64:  return 0;
         case 128: return 1;
         case 256: return 2;
         case 512: return 3;
+        case 1024: return 4;
+        case 2048: return 5;
+        case 4096: return 6;
+        case 8192: return 7;
         default:  return -1;
     }
 }
@@ -10027,7 +10048,8 @@ static void ggml_vk_fwht(ggml_backend_vk_context * ctx, vk_context& subctx, cons
     const int idx = ggml_vk_fwht_pipeline_idx(src->ne[0]);
     vk_pipeline pipeline = src->type == GGML_TYPE_F16 ? ctx->device->pipeline_fwht_f16[idx] : ctx->device->pipeline_fwht_f32[idx];
 
-    const uint32_t rows_per_workgroup = 4;
+    const uint32_t rows_per_workgroup = ctx->device->fwht_rows_per_wg[idx];
+    GGML_ASSERT(rows_per_workgroup > 0);
     const uint32_t n_rows = (uint32_t)ggml_nrows(src);
     const uint32_t max_workgroups_x = ctx->device->properties.limits.maxComputeWorkGroupCount[0];
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/fwht.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/fwht.comp
@@ -11,8 +11,9 @@
 
 layout(constant_id = 0) const uint BLOCK_SIZE = 32;
 layout(constant_id = 1) const uint N = 128;
+layout(constant_id = 2) const uint ROWS = 4;
 
-layout(local_size_x_id = 0, local_size_y = 4, local_size_z = 1) in;
+layout(local_size_x_id = 0, local_size_y_id = 2, local_size_z = 1) in;
 
 layout(push_constant) uniform parameter
 {
@@ -34,7 +35,7 @@ layout(binding = 1, std430) writeonly buffer D { float data_d[]; };
 const uint EL_W = N / BLOCK_SIZE;
 
 #ifdef FWHT_SHMEM
-shared float shmem[4 * N];
+shared float shmem[ROWS * N];
 #endif
 
 void main() {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9256,6 +9256,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_fwht_signed(4096, 8192, 3));
     test_cases.emplace_back(new test_fwht_signed(4096, 8192, 1,  GGML_TYPE_F16));
     test_cases.emplace_back(new test_fwht_signed(8192, 8192, 2));
+    test_cases.emplace_back(new test_fwht_signed(8192, 8192, 1,  GGML_TYPE_F16));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 32, 1, 32)); // too small (N<64)
 
 #if 0


### PR DESCRIPTION
Port of #154 to `prism`, the same way #153 carried #152 over. #153 brought the CUDA FWHT kernels for wide block widths to this branch; this brings Metal and Vulkan so the three backends cover the same widths here too.

## What

Metal gains block widths 4096 and 8192. Vulkan gains 1024, 2048, 4096 and 8192, having previously stopped at 512.

## Why

Both backends hit the same wall for the same reason. The existing kernels are register resident, holding N/subgroup_size values per lane, so the wide widths stop fitting. Any width without a kernel silently falls back to a dense mul_mat, which is O(N^2) work where the transform is O(N log N).

## How

Metal adds `kernel_fwht_tg`, a threadgroup staged variant that maps one row to a whole threadgroup instead of one simdgroup. Butterflies below the simdgroup width still use `simd_shuffle_xor`, butterflies up to the threadgroup size exchange through threadgroup memory, and the remainder stay in registers. It is instantiated at 4096 and 8192 under the existing `kernel_fwht_<type>_<n>` names, so the host side lookup is unchanged. The threshold and thread count live in `ggml-metal-impl.h`, which both the host and the shader include, so the dispatch and the kernel cannot disagree.

Vulkan needed no new shader. `fwht.comp` was already parameterised by specialization constants, so the change is to pick the shape per width: the subgroup shader keeps the narrow widths, and wider blocks use the shared memory shader with one row per workgroup, which keeps the register block small and the staging buffer at N floats rather than 4N. Rows per workgroup becomes a specialization constant instead of a hardcoded 4, and the value chosen when the pipeline is built is recorded on the device so `ggml_vk_fwht` dispatches a matching workgroup count. Widths that would exceed `maxComputeSharedMemorySize` or `maxComputeWorkGroupInvocations` leave a null pipeline, which already makes `ggml_vk_can_use_fwht` fall back.

The Vulkan cutoff keys on `n / subgroup_size` and not on `n` alone. The subgroup shader pins its block to the subgroup width, so a device reporting a narrow subgroup reaches the same register wall at a smaller width: at subgroup_size 16 a 2048 block is already 128 values per invocation. The ratio test is a no-op on the 32 and 64 wide subgroups and routes the narrow ones to the shared memory shader.

The divisor is clamped with `std::max(device->subgroup_size, 1u)`. That also closes a pre-existing path: the same value already fed `std::min(device->subgroup_size, n)` for the shared memory block size, so a device reporting a subgroup size of zero would have given a zero block size and divided by zero in the shader's `EL_W = N / BLOCK_SIZE`.

## Testing

A pass on its own does not prove much here, because an unsupported width falls back to a generic mul_mat that produces the same answer, so I checked that the new kernel is the thing running.

Rebuilt and retested on this branch rather than relying on the results from #154. Metal on an M5 Pro: 10/10 runnable `MUL_MAT_HADAMARD` cases pass, and the pipeline compile log shows `kernel_fwht_f32_4096` and `kernel_fwht_f32_8192` being built and dispatched. Vulkan on MoltenVK: 13/13 pass.

## Limitations worth knowing

Same two caveats as #154, both still open here.

The Vulkan side is verified on MoltenVK, a translation layer over Metal, not a native desktop driver. Worth a run on native hardware before this is leaned on. Note also that an Intel box whose driver falls inside the existing crash gate in `ggml_vk_load_shaders` creates no FWHT pipelines at all, so the whole suite passes there purely by fallback and looks identical to an unmodified tree. A green result on Intel means nothing without checking the driver version first.

The f16 `MUL_MAT_HADAMARD` cases report "not supported" on Metal at every width, including the ones that worked before this change. That is not related to FWHT: the test graph applies the sign vector as `ggml_mul(x_f16, s_f32)` and the Metal elementwise path requires matching operand types, so the graph falls back. Vulkan accepts the mixed types and runs those cases.
