### PR TITLE
metal: TQ1_0 kernel performance (dense decode +39-55%, prefill +78-90%)

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -90,7 +90,7 @@
 #define N_R0_IQ4_XS 2
 #define N_SG_IQ4_XS 2
 
-#define N_R0_TQ1_0 4
+#define N_R0_TQ1_0 8
 #define N_SG_TQ1_0 2
 #define N_R0_TQ2_0 4
 #define N_SG_TQ2_0 2

--- a/ggml/src/ggml-metal/kernels/dequantize.h
+++ b/ggml/src/ggml-metal/kernels/dequantize.h
@@ -754,39 +754,47 @@ void dequantize_iq4_xs(device const block_iq4_xs * xb, short il, thread type4x4 
 //   i <  160: qs[i%32]        digit i/32
 //   i <  240: qs[32 + (i-160)%16] digit (i-160)/16
 //   i <  256: qh[(i-240)%4]   digit (i-240)/4
-// A digit is recovered by multiplying the byte by 3^n modulo 256 and taking the
-// top of (q*3), which is the same trick the CPU reference uses.
-static inline float tq1_0_trit(uchar b, short n) {
-    const uchar pow3[5] = {1, 3, 9, 27, 81};
-    const uchar q  = (uchar) ((uint) b * (uint) pow3[n]);
-    const short xi = (short) ((((ushort) q) * 3) >> 8);
-    return (float) (xi - 1);
-}
-
+//
+// A packed byte is a base-3 fraction of 256: with u = b/256, digit n is
+//   g_{n+1} - 3*g_n,   g_k = floor(3^k * u)
+// and 3^k*b <= 61965 is exact in fp32, so this matches the integer reference bit
+// for bit while staying in the float pipe, which matters on an ISA that cannot
+// co-issue integer and floating-point work.
+//
+// The sixteen elements of one call also share a digit index. For il < 10 they are
+// sixteen consecutive bytes of the 32-byte qs region at digit il/2; for
+// 10 <= il < 15 they are sixteen consecutive bytes of the 16-byte region at digit
+// il-10; only il == 15 walks the qh tail, which packs four digits into four bytes.
+// Hoisting that turns the per-element modulo, divide and integer multiply-shift
+// into two loop-invariant constants and a floor.
 template <typename type4x4>
 void dequantize_tq1_0(device const block_tq1_0 * xb, short il, thread type4x4 & reg) {
-    device const uint8_t * qs = xb->qs;
-    device const uint8_t * qh = xb->qh;
+    const float pow3f[5] = {1.0f, 3.0f, 9.0f, 27.0f, 81.0f};
+
     const float d = xb->d;
 
     float4x4 reg_f;
 
-    const short base = il * 16;
-    for (short k = 0; k < 16; k++) {
-        const short i = base + k;
+    if (il < 15) {
+        device const uint8_t * p = xb->qs + (il < 10 ? (il & 1)*16 : 32);
 
-        float v;
-        if (i < 160) {
-            v = tq1_0_trit(qs[i % 32], i / 32);
-        } else if (i < 240) {
-            const short t = i - 160;
-            v = tq1_0_trit(qs[32 + (t % 16)], t / 16);
-        } else {
-            const short t = i - 240;
-            v = tq1_0_trit(qh[t % 4], t / 4);
+        const float c0 = pow3f[il < 10 ? (il >> 1) : (il - 10)];
+        const float c1 = 3.0f*c0;
+
+        for (short k = 0; k < 16; k++) {
+            const float u = (float) p[k] * (1.0f/256.0f);
+
+            reg_f[k/4][k%4] = d*(floor(c1*u) - 3.0f*floor(c0*u) - 1.0f);
         }
+    } else {
+        device const uint8_t * p = xb->qh;
 
-        reg_f[k/4][k%4] = d * v;
+        for (short k = 0; k < 16; k++) {
+            const float c0 = pow3f[k >> 2];
+            const float u  = (float) p[k & 3] * (1.0f/256.0f);
+
+            reg_f[k/4][k%4] = d*(floor(3.0f*c0*u) - 3.0f*floor(c0*u) - 1.0f);
+        }
     }
 
     reg = (type4x4) reg_f;

--- a/ggml/src/ggml-metal/kernels/dequantize.h
+++ b/ggml/src/ggml-metal/kernels/dequantize.h
@@ -757,16 +757,9 @@ void dequantize_iq4_xs(device const block_iq4_xs * xb, short il, thread type4x4 
 //
 // A packed byte is a base-3 fraction of 256: with u = b/256, digit n is
 //   g_{n+1} - 3*g_n,   g_k = floor(3^k * u)
-// and 3^k*b <= 61965 is exact in fp32, so this matches the integer reference bit
-// for bit while staying in the float pipe, which matters on an ISA that cannot
-// co-issue integer and floating-point work.
-//
-// The sixteen elements of one call also share a digit index. For il < 10 they are
-// sixteen consecutive bytes of the 32-byte qs region at digit il/2; for
-// 10 <= il < 15 they are sixteen consecutive bytes of the 16-byte region at digit
-// il-10; only il == 15 walks the qh tail, which packs four digits into four bytes.
-// Hoisting that turns the per-element modulo, divide and integer multiply-shift
-// into two loop-invariant constants and a floor.
+// 3^k*b <= 61965 is exact in fp32, so this matches the integer reference bit for bit in the float pipe.
+// That matters on an ISA that cannot co-issue integer and floating-point work.
+// The sixteen elements of one call share a digit index, so their integer work hoists to two loop-invariant constants and a floor.
 template <typename type4x4>
 void dequantize_tq1_0(device const block_tq1_0 * xb, short il, thread type4x4 & reg) {
     const float pow3f[5] = {1.0f, 3.0f, 9.0f, 27.0f, 81.0f};

--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
@@ -3132,8 +3132,12 @@ void kernel_mul_mv_tq1_0_f32_impl(
 
     float sumf[nr0] = {0.f};
 
-    const bool hasB = tiisg < 16;
-    const bool hasC = tiisg <  4;
+    // qs[48] and qh[4] are contiguous, so a block's packed payload is a flat 52
+    // bytes. Lane l takes byte l and byte 32+l, which covers all 52 in two passes
+    // instead of the three (32 then 16 then 4 lanes busy) the region layout
+    // suggests: 81% of lanes busy rather than 54%. Lanes 20..31 have no second
+    // byte, so they get zero coefficients and a clamped index and add nothing.
+    const short j1 = min((short) (32 + tiisg), (short) 51);
 
     for (int ib = 0; ib < nb; ++ib) {
         device const float * yb = y + ib*QK_K;
@@ -3148,80 +3152,69 @@ void kernel_mul_mv_tq1_0_f32_impl(
         // row loop. That leaves one floor and one fma per element in the inner loop and
         // no integer arithmetic at all, which matters because this ISA cannot co-issue
         // integer and floating-point work.
-        float cA[5], cB[5], cC[4];
-        float sumyA = 0.f, sumyB = 0.f, sumyC = 0.f;
+        float c0[5], c1[5];
+        float sumy0 = 0.f, sumy1 = 0.f;
 
         {
-            float yA[5];
+            float y0[5];
             FOR_UNROLL (short n = 0; n < 5; ++n) {
-                yA[n] = yb[n*32 + tiisg];
+                y0[n] = yb[n*32 + tiisg];
             }
             FOR_UNROLL (short k = 1; k < 5; ++k) {
-                cA[k-1] = yA[k-1] - 3.0f*yA[k];
+                c0[k-1] = y0[k-1] - 3.0f*y0[k];
             }
-            cA[4] = yA[4];
-            sumyA = ((yA[0] + yA[1]) + (yA[2] + yA[3])) + yA[4];
+            c0[4] = y0[4];
+            sumy0 = ((y0[0] + y0[1]) + (y0[2] + y0[3])) + y0[4];
         }
 
-        if (hasB) {
-            float yB[5];
-            FOR_UNROLL (short n = 0; n < 5; ++n) {
-                yB[n] = yb[160 + n*16 + tiisg];
+        {
+            // The qh tail carries 4 digits per byte rather than 5. Padding its fifth
+            // activation with zero makes the five-digit collapse reproduce the
+            // four-digit one exactly (the g_5 coefficient becomes 0 and the g_4 one
+            // becomes y_3), so both tails run the same code and the pass does not
+            // diverge. Lanes past the payload keep all-zero activations and add zero.
+            float y1[5] = { 0.f, 0.f, 0.f, 0.f, 0.f };
+            if (tiisg < 16) {
+                FOR_UNROLL (short n = 0; n < 5; ++n) {
+                    y1[n] = yb[160 + n*16 + tiisg];
+                }
+            } else if (tiisg < 20) {
+                FOR_UNROLL (short n = 0; n < 4; ++n) {
+                    y1[n] = yb[240 + n*4 + (tiisg - 16)];
+                }
             }
             FOR_UNROLL (short k = 1; k < 5; ++k) {
-                cB[k-1] = yB[k-1] - 3.0f*yB[k];
+                c1[k-1] = y1[k-1] - 3.0f*y1[k];
             }
-            cB[4] = yB[4];
-            sumyB = ((yB[0] + yB[1]) + (yB[2] + yB[3])) + yB[4];
-        }
-
-        if (hasC) {
-            // the qh tail carries 4 digits per byte, not 5
-            float yC[4];
-            FOR_UNROLL (short n = 0; n < 4; ++n) {
-                yC[n] = yb[240 + n*4 + tiisg];
-            }
-            FOR_UNROLL (short k = 1; k < 4; ++k) {
-                cC[k-1] = yC[k-1] - 3.0f*yC[k];
-            }
-            cC[3] = yC[3];
-            sumyC = (yC[0] + yC[1]) + (yC[2] + yC[3]);
+            c1[4] = y1[4];
+            sumy1 = ((y1[0] + y1[1]) + (y1[2] + y1[3])) + y1[4];
         }
 
         FOR_UNROLL (short row = 0; row < nr0; ++row) {
             device const block_tq1_0 & xb = ax[row][ib];
+            device const uint8_t * xq = (device const uint8_t *) &xb;
 
             float sum = 0.f;
 
             {
-                const float u = (float) xb.qs[tiisg] * (1.0f/256.0f);
-                float acc = -sumyA;
-                acc += floor(  3.0f*u)*cA[0];
-                acc += floor(  9.0f*u)*cA[1];
-                acc += floor( 27.0f*u)*cA[2];
-                acc += floor( 81.0f*u)*cA[3];
-                acc += floor(243.0f*u)*cA[4];
+                const float u = (float) xq[tiisg] * (1.0f/256.0f);
+                float acc = -sumy0;
+                acc += floor(  3.0f*u)*c0[0];
+                acc += floor(  9.0f*u)*c0[1];
+                acc += floor( 27.0f*u)*c0[2];
+                acc += floor( 81.0f*u)*c0[3];
+                acc += floor(243.0f*u)*c0[4];
                 sum += acc;
             }
 
-            if (hasB) {
-                const float u = (float) xb.qs[32 + tiisg] * (1.0f/256.0f);
-                float acc = -sumyB;
-                acc += floor(  3.0f*u)*cB[0];
-                acc += floor(  9.0f*u)*cB[1];
-                acc += floor( 27.0f*u)*cB[2];
-                acc += floor( 81.0f*u)*cB[3];
-                acc += floor(243.0f*u)*cB[4];
-                sum += acc;
-            }
-
-            if (hasC) {
-                const float u = (float) xb.qh[tiisg] * (1.0f/256.0f);
-                float acc = -sumyC;
-                acc += floor( 3.0f*u)*cC[0];
-                acc += floor( 9.0f*u)*cC[1];
-                acc += floor(27.0f*u)*cC[2];
-                acc += floor(81.0f*u)*cC[3];
+            {
+                const float u = (float) xq[j1] * (1.0f/256.0f);
+                float acc = -sumy1;
+                acc += floor(  3.0f*u)*c1[0];
+                acc += floor(  9.0f*u)*c1[1];
+                acc += floor( 27.0f*u)*c1[2];
+                acc += floor( 81.0f*u)*c1[3];
+                acc += floor(243.0f*u)*c1[4];
                 sum += acc;
             }
 

--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
@@ -3132,11 +3132,9 @@ void kernel_mul_mv_tq1_0_f32_impl(
 
     float sumf[nr0] = {0.f};
 
-    // qs[48] and qh[4] are contiguous, so a block's packed payload is a flat 52
-    // bytes. Lane l takes byte l and byte 32+l, which covers all 52 in two passes
-    // instead of the three (32 then 16 then 4 lanes busy) the region layout
-    // suggests: 81% of lanes busy rather than 54%. Lanes 20..31 have no second
-    // byte, so they get zero coefficients and a clamped index and add nothing.
+    // qs[48] and qh[4] are contiguous, so a block's packed payload is a flat 52 bytes.
+    // Lane l takes byte l and byte 32+l, covering all 52 in two passes instead of three: 81% of lanes busy rather than 54%.
+    // Lanes 20..31 have no second byte, so they get zero coefficients and a clamped index and add nothing.
     const short j1 = min((short) (32 + tiisg), (short) 51);
 
     for (int ib = 0; ib < nb; ++ib) {
@@ -3168,11 +3166,9 @@ void kernel_mul_mv_tq1_0_f32_impl(
         }
 
         {
-            // The qh tail carries 4 digits per byte rather than 5. Padding its fifth
-            // activation with zero makes the five-digit collapse reproduce the
-            // four-digit one exactly (the g_5 coefficient becomes 0 and the g_4 one
-            // becomes y_3), so both tails run the same code and the pass does not
-            // diverge. Lanes past the payload keep all-zero activations and add zero.
+            // The qh tail carries 4 digits per byte rather than 5, so its fifth activation is padded with zero.
+            // That reproduces the four-digit collapse exactly: the g_5 coefficient becomes 0 and the g_4 one becomes y_3, so both tails run the same code.
+            // Lanes past the payload keep all-zero activations and add zero.
             float y1[5] = { 0.f, 0.f, 0.f, 0.f, 0.f };
             if (tiisg < 16) {
                 FOR_UNROLL (short n = 0; n < 5; ++n) {


### PR DESCRIPTION
Two performance changes to the Metal TQ1_0 kernels. Stacked on `feat/tq1_0-cuda-v7`, which carries the kernels themselves and has no PR of its own yet, so the base here is that branch rather than `prism-v7`. Relates to #141.

Measured on an M5 Pro with `llama-bench -p 512 -n 128 -r 3`, across four ternary models: three dense, spanning roughly a five times parameter range, plus one mixture-of-experts. Three build arms were used, each in its own worktree, with the embedded shader confirmed distinct before every run.

| model | decode | prefill |
|---|---|---|
| dense, smallest | +45.7% | +82.6% |
| dense, middle | +39.1% | +78.4% |
| dense, largest | +55.2% | +89.7% |
| mixture-of-experts | +21.8% | +112% |

The decode gain is consistently larger on the dense models, 39 to 55 percent, than on the MoE at 21.8 percent. Dense decode is dominated by the mat-vec kernel this change touches, whereas the MoE spends a meaningful share of its decode in routing and gather work that dilutes the improvement. Prefill improves substantially everywhere.

For scale on the smallest dense model, where a same-binary TQ2_0 comparison was also taken: TQ1_0 moves from 53 percent of TQ2_0 prefill and 61 percent of its decode, to 96.5 percent and 88.8 percent respectively, at 82 percent of the file size. TQ2_0 still wins both axes, so this is now a size against speed trade rather than TQ1_0 being uncompetitive.

The two changes are independent and touch different paths, so they are separate commits.

## 1. Flatten the mat-vec into two uniform passes (decode)

The mat-vec walked a block's payload as three regions of 32, 16 and 4 bytes, each behind its own lane predicate. The second and third passes leave most of the simdgroup idle while the group still waits for them, so only 52 of 96 lane-slots do useful work.

`qs[48]` and `qh[4]` are adjacent in `block_tq1_0`, so the payload is really a flat 52 bytes. Lane `l` now takes byte `l` and byte `32 + l`, covering all 52 in two passes at 52 of 64 slots.

The obstacle is that the tails carry different digit counts, five per byte for `qs` and four for `qh`, so running them together would reintroduce the divergence being removed. Padding the `qh` tail's fifth activation with zero makes the five-digit collapse reproduce the four-digit one exactly: the `g_5` coefficient becomes zero and `g_4` becomes `y_3`, which is the four-digit form. Both tails then share one code path. Lanes past the payload get zero coefficients and a clamped index, so they read in bounds and add nothing.

## 2. Remove the per-element integer work from the dequantize (prefill)

Prefill reaches TQ1_0 through the element-indexed dequantize template, which recomputed a modulo, a divide and an integer multiply-shift for every one of the sixteen elements it produced. On an ISA that cannot co-issue integer and floating-point work, that dominated.

Those sixteen elements share a digit index. For `il < 10` they are sixteen consecutive bytes of the 32-byte region at digit `il/2`; for `10 <= il < 15`, sixteen consecutive bytes of the 16-byte region at digit `il-10`; only `il == 15` walks the `qh` tail. Hoisting that leaves two loop-invariant constants, and the digit comes from the same exact-float identity the mat-vec already uses, so the inner loop is a floor pair with no integer arithmetic.

Note this does **not** fix the underlying five times byte re-read, which is inherent to the sixteen-contiguous-element interface. A block-at-a-time unpack into the shared-memory tile is still available on top of this.

## Correctness

Both digit identities were checked against the integer reference before the kernels were touched: the zero-padded collapse over all 256 byte values, and the rewritten dequantize over 77824 elements covering every `il` including extreme bytes. `test-backend-ops` on Metal passes 17 `MUL_MAT`, 7 `MUL_MAT_ID` and 4 `GET_ROWS` tq1_0 cases with zero failures after each change.

The dequantize change is bit-identical: per-element values are unchanged and nothing is repartitioned, and greedy generation matches the previous commit exactly apart from the build stamp.

The flatten change is **not** bit-identical, and should not be expected to be. It moves the `qh` tail off lanes 0-3 and onto lanes 16-19, so the simdgroup reduction sums a different partition of the same terms and fp32 reassociation shifts the last bits, by about the magnitude the existing five-digit path already carries. The transform is algebraically exact; only the reduction order moves. On the degenerate bench model used here, whose top-two logits are nearly tied, greedy decoding follows the same tokens for a short prefix and then diverges.

An earlier revision of this description claimed byte-identical greedy output for the flatten change. That was measured against a baseline build directory whose Metal dylib had since been rebuilt from modified sources, so it compared the change against itself. The claim is withdrawn.

## Measuring this yourself

Two traps, both of which produced wrong answers here before being caught.

`GGML_METAL_PATH_RESOURCES` is only consulted when no precompiled metallib exists. This build logs `using embedded metal library`, meaning the shader is baked into `libggml-metal.dylib`, so pointing that variable at two source trees changes nothing. Appending `#error` to one tree and still getting a clean run is what exposed it.

Separate build directories in one source tree are not sufficient either. Building any target in a directory re-derives its dylib from whatever the sources currently say, so a baseline verified at setup can be silently overwritten later. Use separate worktrees, and re-confirm with `strings <dylib> | grep -c <marker>` immediately before each measurement rather than once. The build banner is not provenance: it records the commit at configure time and will report a clean SHA for a binary containing uncommitted changes.

## Not applicable

fp16 for the digit extraction does not work, recorded so nobody retries it. The method needs `floor(3^k * b / 256)` exact; at `3^5 * 255 = 61965` the fp16 spacing is 32, so consecutive integers are not representable. Measured over all bytes it gets 17 of 1280 digits wrong, for example byte 79 digit 3 yields 1 where the reference gives 0, a wrong ternary level rather than a rounding difference. Resolving the 1/256 fractional steps needs roughly 16 mantissa bits and fp16 has 11, so even the first digit fails.
