### PR TITLE
metal: PTQ1_0 exact-float trit extraction (+30-38% decode) and the missing per-expert mat-vec

### DIFF
--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
@@ -862,46 +862,48 @@ kernel void kernel_mul_mv_q2_0_f32(
 //   qs[2*it], qs[2*it+1]  -> elements n*16 + m        for n in 0..4
 //   qs[16 + it]           -> elements 80 + n*8 + it   for n in 0..4
 //   qh[it] (it < 2 only)  -> elements 120 + n*2 + it  for n in 0..3
-// Dot against y already staged in registers by the caller and reused across all nr0
-// rows. Trits come out of the byte by the base-3 remainder recurrence
-//   t = (v*3) >> 8,  v = (v*3) & 0xFF,  v starting at the byte
-// which is two integer ops per trit with no table and no pow3 lookup. A 256-entry
-// lookup was measurably worse here: it adds a dependent load per byte, and decode on
-// this kernel is instruction-bound, not bandwidth-bound. Verified against the
-// reference decode for all 256 bytes and all five positions.
-// Accumulates the raw 0/1/2 trit and subtracts the staged y sum once, so there is no
-// per-element offset correction.
+// Dot against coefficients already staged in registers by the caller and reused across
+// all nr0 rows. A packed byte is a base-3 fraction of 256: with u = b/256, trit n is
+//   t_n = g_{n+1} - 3*g_n,   g_k = floor(3^k * u)
+// and 3^k*b <= 61965 is exact in fp32, so the floors are exact and this matches the
+// integer recurrence bit for bit over all 256 bytes and all five positions. Summing
+// t_n*y_n over a byte's trits then collapses to
+//   sum_{k=1..4} g_k*(y_{k-1} - 3*y_k) + g_5*y_4
+// whose coefficients depend only on the activations, so the caller stages those in
+// place of the raw y. The inner loop is one floor and one fma per trit and never
+// leaves the float pipe, which matters because this ISA cannot co-issue integer and
+// floating-point work; the recurrence spent four integer ops and a convert per trit.
+// sumy is subtracted once for the -1 offset, exactly as before.
 inline float ptq1_0_dot_reg(device const block_ptq1_0 * qb, thread const float * yl, float sumy, short it) {
     float acc = 0.f;
-    short c = 0;
 
     FOR_UNROLL (short k = 0; k < 2; ++k) {
-        ushort v = qb->qs[2*it + k];
-        FOR_UNROLL (short n = 0; n < 5; ++n) {
-            const ushort w = v * 3;
-            acc += (float) (w >> 8) * yl[c++];
-            v = w & 0xFF;
-        }
+        const float u = (float) qb->qs[2*it + k] * (1.0f/256.0f);
+        thread const float * c = yl + 5*k;
+        acc += floor(  3.0f*u)*c[0];
+        acc += floor(  9.0f*u)*c[1];
+        acc += floor( 27.0f*u)*c[2];
+        acc += floor( 81.0f*u)*c[3];
+        acc += floor(243.0f*u)*c[4];
     }
 
     {
-        ushort v = qb->qs[16 + it];
-        FOR_UNROLL (short n = 0; n < 5; ++n) {
-            const ushort w = v * 3;
-            acc += (float) (w >> 8) * yl[c++];
-            v = w & 0xFF;
-        }
+        const float u = (float) qb->qs[16 + it] * (1.0f/256.0f);
+        thread const float * c = yl + 10;
+        acc += floor(  3.0f*u)*c[0];
+        acc += floor(  9.0f*u)*c[1];
+        acc += floor( 27.0f*u)*c[2];
+        acc += floor( 81.0f*u)*c[3];
+        acc += floor(243.0f*u)*c[4];
     }
 
-    // qh holds 8 elements; give every thread exactly one so all eight do 16 elements.
-    // Element 120+it sits at trit it>>1 of byte qh[it&1], so step the recurrence to it.
+    // qh holds 8 elements; every thread takes exactly one, trit it>>1 of byte qh[it&1].
+    // The single-trit form is two floors and replaces a lane-divergent loop that
+    // stepped the recurrence up to three times.
     {
-        ushort v = qb->qh[it & 1];
-        const short n = it >> 1;
-        for (short i = 0; i < n; ++i) {
-            v = (v * 3) & 0xFF;
-        }
-        acc += (float) ((v * 3) >> 8) * yl[c++];
+        const float u  = (float) qb->qh[it & 1] * (1.0f/256.0f);
+        const float p0 = yl[16];                      // 3^n for this thread's trit
+        acc += (floor(3.0f*p0*u) - 3.0f*floor(p0*u)) * yl[15];
     }
 
     return (acc - sumy) * (float) qb->d;
@@ -940,7 +942,8 @@ void kernel_mul_mv_ptq1_0_f32_impl(
         ax[row] = (device const block_ptq1_0 *) ((device char *) src0 + offset0);
     }
 
-    float yl[16];
+    // 15 collapse coefficients, the qh activation, and the qh trit's 3^n
+    float yl[17];
     float sumf[nr0] = {0.f};
 
     // eight threads cover one 128-weight block; each owns whole bytes, not a
@@ -950,28 +953,43 @@ void kernel_mul_mv_ptq1_0_f32_impl(
 
     device const float * yb = y + ix*QK_PTQ1_0;
 
+    {
+        const float pow3f[4] = {1.0f, 3.0f, 9.0f, 27.0f};
+        yl[16] = pow3f[it >> 1];
+    }
+
     for (int ib = ix; ib < nb; ib += N_SIMDWIDTH/8) {
-        // stage this thread's y values once, then reuse them for every row
+        // stage this thread's activations once as collapse coefficients, then reuse
+        // them for every row: c[k-1] = y_{k-1} - 3*y_k for k = 1..4, c[4] = y_4
         float sumy = 0.f;
-        short c = 0;
 
         FOR_UNROLL (short k = 0; k < 2; ++k) {
             const short m = 2*it + k;
+            float y[5];
             FOR_UNROLL (short n = 0; n < 5; ++n) {
-                const float v = yb[n*16 + m];
-                yl[c++] = v;
-                sumy   += v;
+                y[n]  = yb[n*16 + m];
+                sumy += y[n];
             }
+            FOR_UNROLL (short n = 0; n < 4; ++n) {
+                yl[5*k + n] = y[n] - 3.0f*y[n+1];
+            }
+            yl[5*k + 4] = y[4];
         }
-        FOR_UNROLL (short n = 0; n < 5; ++n) {
-            const float v = yb[80 + n*8 + it];
-            yl[c++] = v;
-            sumy   += v;
+        {
+            float y[5];
+            FOR_UNROLL (short n = 0; n < 5; ++n) {
+                y[n]  = yb[80 + n*8 + it];
+                sumy += y[n];
+            }
+            FOR_UNROLL (short n = 0; n < 4; ++n) {
+                yl[10 + n] = y[n] - 3.0f*y[n+1];
+            }
+            yl[14] = y[4];
         }
         {
             const float v = yb[120 + it];
-            yl[c++] = v;
-            sumy   += v;
+            yl[15] = v;
+            sumy  += v;
         }
 
         FOR_UNROLL (short row = 0; row < nr0; row++) {

--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
@@ -3852,6 +3852,7 @@ template [[host_name("kernel_mul_mv_id_q8_0_f32")]]    kernel kernel_mul_mv_id_t
 template [[host_name("kernel_mul_mv_id_q1_0_f32")]]    kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<kernel_mul_mv_q1_0_f32_impl<N_R0_Q1_0>>>;
 template [[host_name("kernel_mul_mv_id_q2_0_f32")]]    kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<kernel_mul_mv_q2_0_f32_impl<N_R0_Q2_0>>>;
 template [[host_name("kernel_mul_mv_id_pq2_0_f32")]]   kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<kernel_mul_mv_pq2_0_f32_impl<N_R0_PQ2_0>>>;
+template [[host_name("kernel_mul_mv_id_ptq1_0_f32")]]  kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<kernel_mul_mv_ptq1_0_f32_impl<N_R0_PTQ1_0>>>;
 template [[host_name("kernel_mul_mv_id_q4_0_f32")]]    kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<mul_vec_q_n_f32_impl<block_q4_0, N_R0_Q4_0>>>;
 template [[host_name("kernel_mul_mv_id_q4_1_f32")]]    kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<mul_vec_q_n_f32_impl<block_q4_1, N_R0_Q4_1>>>;
 template [[host_name("kernel_mul_mv_id_q5_0_f32")]]    kernel kernel_mul_mv_id_t kernel_mul_mv_id<mmv_fn<mul_vec_q_n_f32_impl<block_q5_0, N_R0_Q5_0>>>;


### PR DESCRIPTION
Two changes to the Metal PTQ1_0 mat-vec: a decode speedup, and a missing kernel whose absence segfaults any PTQ1_0 mixture-of-experts model on Metal today.

## Decode: extract trits in exact float

The mat-vec pulled each trit out of its byte with the base-3 remainder recurrence, `w = v*3; t = w >> 8; v = w & 0xFF`. That is four integer ops and a convert per trit, on an ISA that cannot co-issue integer and floating-point work, and the kernel's own comment records that it is instruction-bound rather than bandwidth-bound. So the integer work was the ceiling.

A packed byte is a base-3 fraction of 256. With `u = b/256`, trit `n` is `g_{n+1} - 3*g_n` for `g_k = floor(3^k * u)`, and every `3^k * b` is below 2^24, so the floors are exact: this matches the recurrence bit for bit over all 256 bytes and all five positions. Summing `t_n * y_n` over a byte then collapses to `sum_k g_k*(y_{k-1} - 3*y_k) + g_5*y_4`, whose coefficients depend only on the activations, so the caller stages those in place of the raw `y` and reuses them across every row exactly as it did before. The inner loop is one floor and one fma per trit with no integer arithmetic. The `qh` trit uses the two-floor single-trit form, which replaces a lane-divergent loop that stepped the recurrence up to three times.

Measured on an M5 Pro, `llama-bench -p 512 -n 128 -r 3`, two interleaved passes, two dense models roughly five times apart in size:

| | decode before | decode after | prefill |
|---|---|---|---|
| smaller dense | 221 | 287 tok/s, +29.5% | unchanged |
| larger dense | 59.3 | 81.7 tok/s, +37.8% | unchanged |

For scale, on the smaller model the same-binary TQ2_0 decode is 290, so PTQ1_0 now decodes at 99 percent of TQ2_0 at 1.75 versus 2.06 bits per weight. Prefill is untouched because the mat-mul path does not use this routine.

Output is not bit-identical to the previous kernel and should not be expected to be: staging coefficients reassociates the fp32 sum. The per-element values are exact; only summation order moves.

## Correctness bug: the per-expert kernel did not exist

`supports_op` accepts PTQ1_0 for `MUL_MAT_ID` and the dispatcher has an `nsg`/`nr0` entry for it, but `kernel_mul_mv_id_ptq1_0_f32` was never instantiated. The first per-expert PTQ1_0 mat-vec on Metal fails the library lookup (`kernel not found in any metal library`) and the process segfaults. On current `prism-v7` that is any PTQ1_0 MoE model.

It also hid itself in the test suite. `test-backend-ops -o MUL_MAT_ID` on Metal dies on its first PTQ1_0 case, which happens to come right after the `pq2_0` case in the type list, so the run printed 24 clean cases and stopped. Nothing after that point, for any type, was being exercised, and the truncated output looks like a complete pass unless you count the cases or check the exit code. With the instantiation added the same run completes: 1022 `MUL_MAT_ID` cases, 75 of them PTQ1_0, zero failures, 3/3 backends.

The instantiation reuses the existing impl, so it inherits the extraction change above.

## Verification

The identity was checked against the recurrence for all 256 bytes and all positions before the kernel was touched, and the collapse checked exact against the raw trit sum. `test-backend-ops` on Metal: `MUL_MAT` 45/45, `GET_ROWS` 4/4, `MUL_MAT_ID` 75/75 PTQ1_0 cases, zero failures. The A/B used two build directories with the embedded shader confirmed distinct by `strings` immediately before each measurement, since the shader is baked into `libggml-metal.dylib` and a stale or rebuilt arm silently invalidates the comparison.

## Heads-up for the reviewer

There is uncommitted PTQ1_0 Metal work in another session's worktree on `feat/tq1_0-g128` (a qh-only simdgroup broadcast, per its own notes). It touches the same `ptq1_0_dot_reg` and will need reconciling with this if both land.
