### PR TITLE
metal: PQ2_0 and Q2_0 mat-vec dot in exact float (+5-7% decode)

### DIFF
--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
@@ -1022,6 +1022,33 @@ kernel void kernel_mul_mv_ptq1_0_f32(
     kernel_mul_mv_ptq1_0_f32_impl<N_R0_PTQ1_0, constant ggml_metal_kargs_mul_mv &>(args, src0, src1, dst, nullptr, tgpig, tiisg, sgitg);
 }
 
+// PQ2_0 dot against coefficients staged by the caller. A byte is a base-4 fraction of
+// 256: with u = b/256 and g_k = floor(4^k*u), exact in fp32, the floor chain peels the
+// fields from the top down, g_1 = t_3, g_2 - 4*g_1 = t_2, g_3 - 4*g_2 = t_1 and
+// b - 4*g_3 = t_0, because plain bit packing keeps field 0 in the low bits. Summing
+// t_n*y_n over the four fields therefore collapses to
+//   g_1*(y_3 - 4*y_2) + g_2*(y_2 - 4*y_1) + g_3*(y_1 - 4*y_0) + b*y_0
+// so the caller stages those coefficients in place of the raw y and this is three
+// floors and four fmas per byte with no integer work. The select chain it replaces
+// spent two ands, two bool tests and two selects per element, none of which this ISA
+// can co-issue with the float adds. sumy is subtracted once for the -1 offset.
+inline float pq2_0_dot_coeffs(device const block_pq2_0 * qb, float sumy, thread const float * c, int il) {
+    device const uint8_t * qs = qb->qs + (il / 4);
+
+    float acc = 0.f;
+
+    FOR_UNROLL (short j = 0; j < 4; j++) {
+        const float b = (float) qs[j];
+        const float u = b * (1.0f/256.0f);
+        acc += floor( 4.0f*u)*c[4*j + 0];
+        acc += floor(16.0f*u)*c[4*j + 1];
+        acc += floor(64.0f*u)*c[4*j + 2];
+        acc +=              b*c[4*j + 3];
+    }
+
+    return qb->d * (acc - sumy);
+}
+
 template<int nr0, typename args_t>
 void kernel_mul_mv_pq2_0_f32_impl(
         args_t args,
@@ -1065,15 +1092,24 @@ void kernel_mul_mv_pq2_0_f32_impl(
     device const float * yb = y + ix*QK_PQ2_0 + il;
 
     for (int ib = ix; ib < nb; ib += N_SIMDWIDTH/8) {
+        // stage the 16 activations once as base-4 collapse coefficients, reused per row;
+        // the floor chain yields fields top down, so the coefficients pair y_3 with g_1
         float sumy = 0.f;
 
-        FOR_UNROLL (short i = 0; i < 16; i++) {
-            yl[i] = yb[i];
-            sumy += yb[i];
+        FOR_UNROLL (short j = 0; j < 4; j++) {
+            const float y0 = yb[4*j + 0];
+            const float y1 = yb[4*j + 1];
+            const float y2 = yb[4*j + 2];
+            const float y3 = yb[4*j + 3];
+            sumy += (y0 + y1) + (y2 + y3);
+            yl[4*j + 0] = y3 - 4.0f*y2;
+            yl[4*j + 1] = y2 - 4.0f*y1;
+            yl[4*j + 2] = y1 - 4.0f*y0;
+            yl[4*j + 3] = y0;
         }
 
         FOR_UNROLL (short row = 0; row < nr0; row++) {
-            sumf[row] += block_q_n_dot_y(ax[row] + ib, sumy, yl, il);
+            sumf[row] += pq2_0_dot_coeffs(ax[row] + ib, sumy, yl, il);
         }
 
         yb += QK_PQ2_0 * (N_SIMDWIDTH/8);

--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
@@ -813,15 +813,24 @@ void kernel_mul_mv_q2_0_f32_impl(
     device const float * yb = y + ix*QK2_0 + il;
 
     for (int ib = ix; ib < nb; ib += N_SIMDWIDTH/4) {
+        // stage the 16 activations once as base-4 collapse coefficients, reused per row;
+        // the floor chain yields fields top down, so the coefficients pair y_3 with g_1
         float sumy = 0.f;
 
-        FOR_UNROLL (short i = 0; i < 16; i++) {
-            yl[i] = yb[i];
-            sumy += yb[i];
+        FOR_UNROLL (short j = 0; j < 4; j++) {
+            const float y0 = yb[4*j + 0];
+            const float y1 = yb[4*j + 1];
+            const float y2 = yb[4*j + 2];
+            const float y3 = yb[4*j + 3];
+            sumy += (y0 + y1) + (y2 + y3);
+            yl[4*j + 0] = y3 - 4.0f*y2;
+            yl[4*j + 1] = y2 - 4.0f*y1;
+            yl[4*j + 2] = y1 - 4.0f*y0;
+            yl[4*j + 3] = y0;
         }
 
         FOR_UNROLL (short row = 0; row < nr0; row++) {
-            sumf[row] += block_q_n_dot_y(ax[row] + ib, sumy, yl, il);
+            sumf[row] += q2_dot_coeffs(ax[row] + ib, sumy, yl, il);
         }
 
         yb += QK2_0 * (N_SIMDWIDTH/4);
@@ -1022,7 +1031,7 @@ kernel void kernel_mul_mv_ptq1_0_f32(
     kernel_mul_mv_ptq1_0_f32_impl<N_R0_PTQ1_0, constant ggml_metal_kargs_mul_mv &>(args, src0, src1, dst, nullptr, tgpig, tiisg, sgitg);
 }
 
-// PQ2_0 dot against coefficients staged by the caller. A byte is a base-4 fraction of
+// PQ2_0 and Q2_0 dot against coefficients staged by the caller (same codec, group 128 vs 64). A byte is a base-4 fraction of
 // 256: with u = b/256 and g_k = floor(4^k*u), exact in fp32, the floor chain peels the
 // fields from the top down, g_1 = t_3, g_2 - 4*g_1 = t_2, g_3 - 4*g_2 = t_1 and
 // b - 4*g_3 = t_0, because plain bit packing keeps field 0 in the low bits. Summing
@@ -1032,7 +1041,8 @@ kernel void kernel_mul_mv_ptq1_0_f32(
 // floors and four fmas per byte with no integer work. The select chain it replaces
 // spent two ands, two bool tests and two selects per element, none of which this ISA
 // can co-issue with the float adds. sumy is subtracted once for the -1 offset.
-inline float pq2_0_dot_coeffs(device const block_pq2_0 * qb, float sumy, thread const float * c, int il) {
+template <typename block_t>
+inline float q2_dot_coeffs(device const block_t * qb, float sumy, thread const float * c, int il) {
     device const uint8_t * qs = qb->qs + (il / 4);
 
     float acc = 0.f;
@@ -1109,7 +1119,7 @@ void kernel_mul_mv_pq2_0_f32_impl(
         }
 
         FOR_UNROLL (short row = 0; row < nr0; row++) {
-            sumf[row] += pq2_0_dot_coeffs(ax[row] + ib, sumy, yl, il);
+            sumf[row] += q2_dot_coeffs(ax[row] + ib, sumy, yl, il);
         }
 
         yb += QK_PQ2_0 * (N_SIMDWIDTH/8);


### PR DESCRIPTION
The base-4 analogue of the exact-float extraction from #157, applied to the two 2-bit mat-vecs. PQ2_0 and Q2_0 share one codec at group sizes 128 and 64, so one templated dot serves both.

## What

| | decode before | decode after |
|---|---|---|
| PQ2_0, smaller dense | 285.8 | 305.1 tok/s, +6.8% |
| PQ2_0, larger dense | 80.2 | 83.1 tok/s, +3.6% |
| Q2_0, smaller dense | 283.6 | 297.3 tok/s, +4.8% |

M5 Pro, `llama-bench -p 512 -n 128 -r 3`, two interleaved passes. Prefill unchanged in all cases; the mat-mul path does not use this routine.

## Why

The dot accumulated each 2-bit field through two ands, two bool tests, two selects and two adds per element, none of which this ISA can co-issue with the floating-point adds.

## How

A byte is a base-4 fraction of 256. With `u = b/256` and `g_k = floor(4^k * u)`, exact in fp32, the floor chain peels the fields from the top down, because plain bit packing keeps field 0 in the low bits: `g_1` is field 3, `g_2 - 4*g_1` is field 2, `g_3 - 4*g_2` is field 1 and `b - 4*g_3` is field 0. Summing field times activation over a byte collapses to `g_1*(y_3 - 4*y_2) + g_2*(y_2 - 4*y_1) + g_3*(y_1 - 4*y_0) + b*y_0`, whose coefficients depend only on the activations, so the caller stages those in place of the raw `y` and reuses them across every row. Three floors and four fmas per byte, no integer work. The shared select-chain overload is left in place for its other callers.

The field order was checked against the packing over all 256 bytes before the kernel was touched. A first derivation that assumed the base-3 digit order was wrong and was caught by that check; the base-3 codec stores digit 0 as the leading fractional digit, which is why the same chain runs bottom-up there and top-down here.

## What was tried and rejected

The same rewrite on Q1_0 is a measured regression of 5 to 7 percent on two dense models and is not included. With one bit per element the select is already a single op, so seven floors per byte cannot beat it and floor's lower throughput loses. The rule that falls out: the float-floor form pays only where the integer path costs two or more selects, or a multiply-shift chain, per element.

## Where the 2-bit formats now sit

Against a weight-bandwidth ceiling of roughly 270 GB/s, PQ2_0 decode on the larger model is at about 75 percent of the ceiling after this change, so there is little ALU headroom left there. The base-3 formats sit lower (PTQ1_0 about 61 percent, TQ1_0 about 49 percent) and remain the place where kernel work still moves the number.

## Correctness

`test-backend-ops` on Metal, rebuilt on this branch's base: `MUL_MAT` 45 cases pass for each of Q2_0 and PQ2_0 with exit code 0 out of 1719 total; `MUL_MAT_ID` 75 pass for each with exit code 0 out of 1022; Q1_0 is unchanged and passes the same. The collapse is exact; results are not bit-identical to the select chain because the coefficient staging reassociates the fp32 sum. A/B arms were separate build directories with the embedded shader confirmed distinct before each measurement.
