### PR TITLE
metal: fix the PTQ1_0 CPY crash and add the missing PTQ1_0 dequant-copy kernels

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1732,7 +1732,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                            case GGML_TYPE_Q1_0:
                            case GGML_TYPE_Q2_0:
                            case GGML_TYPE_PQ2_0:
-                           case GGML_TYPE_PTQ1_0:
+                           // no Metal quantize_ptq1_0: a CPY into PTQ1_0 falls back to the CPU
                            case GGML_TYPE_Q4_0:
                            case GGML_TYPE_Q4_1:
                            case GGML_TYPE_Q5_0:

--- a/ggml/src/ggml-metal/kernels/quantize.metal
+++ b/ggml/src/ggml-metal/kernels/quantize.metal
@@ -143,6 +143,7 @@ typedef decltype(kernel_cpy_q_f32<float4x4, block_q4_0, 2, dequantize_q4_0>) cpy
 template [[host_name("kernel_cpy_q1_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_q1_0, 8, dequantize_q1_0>;
 template [[host_name("kernel_cpy_q2_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_q2_0, 4, dequantize_q2_0>;
 template [[host_name("kernel_cpy_pq2_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_pq2_0, 8, dequantize_pq2_0>;
+template [[host_name("kernel_cpy_ptq1_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_ptq1_0, 8, dequantize_ptq1_0>;
 template [[host_name("kernel_cpy_q4_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_q4_0, 2, dequantize_q4_0>;
 template [[host_name("kernel_cpy_q4_1_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_q4_1, 2, dequantize_q4_1>;
 template [[host_name("kernel_cpy_q5_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32<float4x4, block_q5_0, 2, dequantize_q5_0>;
@@ -154,6 +155,7 @@ template [[host_name("kernel_cpy_tq2_0_f32")]] kernel cpy_q_f_t kernel_cpy_q_f32
 template [[host_name("kernel_cpy_q1_0_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_q1_0, 8, dequantize_q1_0>;
 template [[host_name("kernel_cpy_q2_0_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_q2_0, 4, dequantize_q2_0>;
 template [[host_name("kernel_cpy_pq2_0_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_pq2_0, 8, dequantize_pq2_0>;
+template [[host_name("kernel_cpy_ptq1_0_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_ptq1_0, 8, dequantize_ptq1_0>;
 template [[host_name("kernel_cpy_q4_0_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_q4_0, 2, dequantize_q4_0>;
 template [[host_name("kernel_cpy_q4_1_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_q4_1, 2, dequantize_q4_1>;
 template [[host_name("kernel_cpy_q5_0_f16")]] kernel cpy_q_f_t kernel_cpy_q_f32<half4x4, block_q5_0, 2, dequantize_q5_0>;


### PR DESCRIPTION
## What

Metal accepted `GGML_OP_CPY` in both directions for `PTQ1_0` while no copy kernel for the type existed. The first such op asked the library for a pipeline that is not there (`kernel not found in any metal library: kernel_cpy_f32_ptq1_0`) and the process died with SIGSEGV.

- `PTQ1_0 -> F32/F16`: instantiate `kernel_cpy_ptq1_0_f32` and `kernel_cpy_ptq1_0_f16` on the existing `cpy_q_f32` template with `dequantize_ptq1_0` (nl = 8, matching the `PQ2_0` copy and the `PTQ1_0` get_rows and mul_mm instantiations).
- `F32 -> PTQ1_0`: decline in `supports_op` so the op falls back to the CPU. There is no Metal `quantize_ptq1_0`.

## Why

Same permissive-gate pattern as the per-expert mat-vec crash fixed in #157: `supports_op` claimed a type the shader library never instantiated. It also made the CPY sweep in `test-backend-ops` look green: the run aborted at the first `PTQ1_0` case, after the `PQ2_0` cases, and everything it had printed was OK.

## Verification

`test-backend-ops test -b MTL0 -o CPY` on an M5 Pro:

| | before | after |
|---|---|---|
| exit code | 139 | 0 |
| result | aborted mid-list | 203/203 passed |
| `PTQ1_0 -> F32` cases | never ran | 2 OK |
| `F32 -> PTQ1_0` cases | crash | 15 not supported (CPU fallback) |

No kernel used by the model graph changes; this only adds instantiations and removes a false capability claim.
