### PR TITLE
cuda: query the device type with cudaDeviceGetAttribute, not cudaGetDeviceProperties (+8% decode)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4847,12 +4847,13 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
 static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend_dev_t dev) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *) dev->context;
 
-    cudaDeviceProp prop;
-    CUDA_CHECK(cudaGetDeviceProperties(&prop, ggml_cuda_get_physical_device(ctx->device)));
+    // A single attribute query, not cudaGetDeviceProperties: this is called on hot host
+    // paths (graph construction queries the device type per layer) and the full property
+    // read costs ~0.7 ms per call, the attribute read ~20 ns.
+    int integrated = 0;
+    CUDA_CHECK(cudaDeviceGetAttribute(&integrated, cudaDevAttrIntegrated, ggml_cuda_get_physical_device(ctx->device)));
 
-    return prop.integrated
-        ? GGML_BACKEND_DEVICE_TYPE_IGPU
-        : GGML_BACKEND_DEVICE_TYPE_GPU;
+    return integrated ? GGML_BACKEND_DEVICE_TYPE_IGPU : GGML_BACKEND_DEVICE_TYPE_GPU;
 }
 
 static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_backend_dev_props * props) {

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -49,6 +49,7 @@
 #define cublasStatus_t hipblasStatus_t
 #define cublasOperation_t hipblasOperation_t
 #define cudaDevAttrCooperativeLaunch hipDeviceAttributeCooperativeLaunch
+#define cudaDevAttrIntegrated                         hipDeviceAttributeIntegrated
 #define cudaDeviceCanAccessPeer hipDeviceCanAccessPeer
 #define cudaDeviceDisablePeerAccess hipDeviceDisablePeerAccess
 #define cudaDeviceEnablePeerAccess hipDeviceEnablePeerAccess


### PR DESCRIPTION
## What

`ggml_backend_cuda_device_get_type` read the whole `cudaDeviceProp` to test the `integrated` flag. It now asks `cudaDeviceGetAttribute(cudaDevAttrIntegrated)`. HIP gets the attribute alias in `vendors/hip.h`; MUSA already resolves the CUDA name.

## Why

The full property read costs about 660 us per call on an H100; the attribute read about 20 ns. The hybrid-attention graph builder queries the device type of every device on every recurrent layer of every graph build, so one decode graph pays it once per recurrent layer, dozens of times. An nsys profile in July put it at 409 `cudaGetDeviceProperties` calls / 337 ms per llama-bench run against 25 calls / 22 ms for upstream, about 0.3 ms per decoded token, and it was the largest identified piece of the fork's host-side decode gap vs upstream.

The graph-side loop is left as is: with the backend call cheap it costs ~2 us per build, and caching it in the model would have to reason about multiple loaded models.

## Verification (L40S, CUDA 12.8, sm_89)

- Build: clean (three builds of the same tree; this change touches no device code).
- `test-backend-ops test -b CUDA0 -o MUL_MAT`: 1283/1283 passed, `-o MUL_MAT_ID`: 1019/1019 passed on the sibling build of the same tree (exit 0 both).
- llama-bench, 9B PTQ1_0 and PQ2_0, r=3, two interleaved passes against base `8c0170d19`:

| 9B band | pp512 base | pp512 fix | tg128 base | tg128 fix | decode |
|---|---|---|---|---|---|
| PTQ1_0 | 5,216 | 5,209 | 170.6 | 183.7 | +7.7% |
| PQ2_0 | 8,364 | 8,317 | 164.6 | 178.2 | +8.2% |

Prefill differences are inside the run-to-run spread (about 8% on this card at pp512); decode error bars are 1 to 4 tok/s.

Bit-exact by construction: no kernel changes, only the host query.
