### PR TITLE
cuda: run the PTQ1_0 MMQ path at every batch (fixes PTQ1_0 CUDA certification), env var to cap it

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -4,6 +4,7 @@
 #include "mmid.cuh"
 
 #include <cstdint>
+#include <cstdlib>
 
 static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
     switch (args.type_x) {
@@ -325,7 +326,14 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
 
 #if !defined(GGML_USE_HIP)
     if (type == GGML_TYPE_PTQ1_0) {
-        return ne11 <= MMQ_PTQ1_0_MAX_BATCH_SIZE;
+        // the fp16 dequantize + cuBLAS fallback is the source of PTQ1_0's extra error on CUDA, so
+        // the MMQ tile path runs at every batch by default; the env var is the A/B knob for
+        // deployments that prefer cuBLAS's ~7% at pp512 over the accuracy
+        static const int64_t max_batch = [] {
+            const char * s = getenv("GGML_CUDA_PTQ1_0_MMQ_MAX_BATCH");
+            return s ? (int64_t) atoll(s) : (int64_t) MMQ_PTQ1_0_MAX_BATCH_SIZE;
+        }();
+        return ne11 <= max_batch;
     }
 #endif
 

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -6,7 +6,7 @@
 #include <cstdint>
 
 #define MMQ_DP4A_MAX_BATCH_SIZE 64  // Max. batch size to use for dp4a MMQ kernels when FP16 tensor cores are available.
-#define MMQ_PTQ1_0_MAX_BATCH_SIZE 64
+#define MMQ_PTQ1_0_MAX_BATCH_SIZE (1 << 30)  // MMQ at every batch unless GGML_CUDA_PTQ1_0_MMQ_MAX_BATCH lowers it
 #define MMQ_ITER_K                256
 #define MMQ_ITER_K_FP4            512
 #define MMQ_NWARPS                8


### PR DESCRIPTION
## What

Follow-up to #160. The PTQ1_0 MMQ tile path landed behind `MMQ_PTQ1_0_MAX_BATCH_SIZE = 64`, so the default ubatch (512) still took the fp16 dequantize + cuBLAS fallback. The cap is now effectively off (MMQ at every batch, like the other low-bit types), and `GGML_CUDA_PTQ1_0_MMQ_MAX_BATCH=<n>` restores a threshold as the A/B knob. HIP stays excluded by the existing guard.

## Why

The fallback is where PTQ1_0's extra error on CUDA comes from. From the #160 review measurements on an L40S (CUDA 12.8), cuBLAS path vs MMQ at full prefill:

| PTQ1_0 | mean KLD, cuBLAS | mean KLD, MMQ | top-1, cuBLAS | top-1, MMQ |
|---|---|---|---|---|
| largest band | 9.2e-4 | 5.6e-4 | 97.78% | 98.39% |
| 9B | 7.7e-4 | 5.0e-4 | 98.26% | 98.60% |

With MMQ the largest PTQ1_0 band clears the top-1 certification gate it was the only shipped band to fail on CUDA, and lands at PQ2_0's level.

Cost: MMQ is about 7% slower than cuBLAS at pp512 on Ada (largest band 1689 -> 1578, 9B 5721 -> 4786, 4B 9249 -> 8361), and faster below roughly ubatch 400 (my own run on a second L40S: 9B ubatch 64 1,332 -> 3,392, 128 1,883 -> 4,232, 256 2,956 -> 4,761, 512 5,206 -> 4,739). Decode is unchanged either way.

## Verification

Host-side selection change only; the kernel it enables is the one #160 gated (MUL_MAT 1283/1283 incl. 45 PTQ1_0, MUL_MAT_ID 1019/1019 incl. 75). The cap-lifted build was measured for KLD and throughput in the #160 review as quoted above.
