### PR TITLE
cuda: block-per-row FWHT for widths 512 and up (+17% / +11% decode on folded bands)

### DIFF
--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -129,12 +129,9 @@ __global__ void fwht_cuda_smem(const T * src, float * dst, const int64_t n_rows,
 }
 
 
-// Wide rows at small row counts (decode): one row per block instead of per warp. The warp kernel
-// keeps N/32 floats per lane and walks log2(N) stages serially on one warp, so at N=2048 a single
-// warp holds 64 registers and the rest of the GPU idles; the shared-memory kernel above pays two
-// __syncthreads per stage for all log2(N) stages. Here each of NT threads holds N/NT values: the
-// stages below the warp width use shuffles, the stages up to NT go through shared memory (three
-// exchanges for NT=256), and the stages above NT stay in registers.
+// Wide rows at small row counts (decode): one row per block instead of per warp.
+// The warp kernel serialises every stage on one warp, and the shared-memory kernel above synchronises on each stage.
+// Both leave most of the GPU idle at these shapes.
 #define FWHT_BLOCK_THREADS 256
 
 template <int N, int NT, typename T, bool has_signs>
@@ -248,10 +245,9 @@ static bool fwht_launch(ggml_backend_cuda_context & ctx, const T * src_d, float 
         default:
             break;
     }
-    // From 512 up, one block of FWHT_BLOCK_THREADS per row (fwht_cuda_block); the warp kernel
-    // serialised the whole transform on one warp and the shared-memory kernel synchronised every
-    // stage, and both were the largest single kernel of a decode step on the folded models.
-    // GGML_CUDA_FWHT_LEGACY=1 restores the previous kernels for A/B.
+    // From 512 up, one block of FWHT_BLOCK_THREADS per row (fwht_cuda_block).
+    // The older kernels were the largest single kernel of a decode step at these widths.
+    // GGML_CUDA_FWHT_LEGACY=1 restores them for A/B.
 #define FWHT_SMEM_CASE(NN) \
         case NN: { \
             const dim3 g((unsigned) rows, 1, 1), b(FWHT_SMEM_THREADS, 1, 1); \

--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -1,6 +1,8 @@
 #include "common.cuh"
 #include "fwht.cuh"
 
+#include <cstdlib>
+
 template <typename T>
 __device__ __forceinline__ float fwht_load(const T value) {
     return value;
@@ -126,6 +128,98 @@ __global__ void fwht_cuda_smem(const T * src, float * dst, const int64_t n_rows,
     }
 }
 
+
+// Wide rows at small row counts (decode): one row per block instead of per warp. The warp kernel
+// keeps N/32 floats per lane and walks log2(N) stages serially on one warp, so at N=2048 a single
+// warp holds 64 registers and the rest of the GPU idles; the shared-memory kernel above pays two
+// __syncthreads per stage for all log2(N) stages. Here each of NT threads holds N/NT values: the
+// stages below the warp width use shuffles, the stages up to NT go through shared memory (three
+// exchanges for NT=256), and the stages above NT stay in registers.
+#define FWHT_BLOCK_THREADS 256
+
+template <int N, int NT, typename T, bool has_signs>
+__launch_bounds__(NT, 1)
+__global__ void fwht_cuda_block(const T * src, float * dst, const int64_t n_rows, const float scale,
+                                const float * signs, const int n_blk) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int NE        = N / NT;
+    static_assert(NE >= 1 && N % NT == 0 && NT % warp_size == 0, "bad FWHT block shape");
+
+    __shared__ float s[N];
+
+    const int64_t r = blockIdx.x;
+    if (r >= n_rows) {
+        return;
+    }
+
+    src += r * N;
+    dst += r * N;
+
+    const int tid  = threadIdx.x;
+    const int lane = tid % warp_size;
+
+    ggml_cuda_pdl_sync();
+    const float * signs_row = has_signs ? signs + (r % n_blk) * N : nullptr;
+
+    float reg[NE];
+#pragma unroll
+    for (int i = 0; i < NE; ++i) {
+        reg[i] = fwht_load(src[i * NT + tid]) * scale;
+        if (has_signs) {
+            reg[i] *= signs_row[i * NT + tid];
+        }
+    }
+
+    // stages within a warp: partner differs in the lane bits
+#pragma unroll
+    for (int h = 1; h < warp_size; h *= 2) {
+#pragma unroll
+        for (int j = 0; j < NE; j++) {
+            const float val  = reg[j];
+            const float val2 = __shfl_xor_sync(0xFFFFFFFF, val, h, warp_size);
+            reg[j] = (lane & h) == 0 ? val + val2 : val2 - val;
+        }
+    }
+
+    // stages across warps: partner differs in the thread-index bits above the lane
+#pragma unroll
+    for (int h = warp_size; h < NT; h *= 2) {
+#pragma unroll
+        for (int j = 0; j < NE; j++) {
+            s[j * NT + tid] = reg[j];
+        }
+        __syncthreads();
+#pragma unroll
+        for (int j = 0; j < NE; j++) {
+            const float val  = reg[j];
+            const float val2 = s[j * NT + (tid ^ h)];
+            reg[j] = (tid & h) == 0 ? val + val2 : val2 - val;
+        }
+        __syncthreads();
+    }
+
+    // stages above the block width: partner is another register of the same thread
+#pragma unroll
+    for (int h = NT; h < N; h *= 2) {
+        const int step = h / NT;
+#pragma unroll
+        for (int j = 0; j < NE; j += 2 * step) {
+#pragma unroll
+            for (int k = 0; k < step; k++) {
+                const float x = reg[j + k];
+                const float y = reg[j + k + step];
+                reg[j + k]        = x + y;
+                reg[j + k + step] = x - y;
+            }
+        }
+    }
+
+#pragma unroll
+    for (int i = 0; i < NE; ++i) {
+        dst[i * NT + tid] = reg[i];
+    }
+}
+
 template <typename T>
 static bool fwht_launch(ggml_backend_cuda_context & ctx, const T * src_d, float * dst_d,
                         const int n, const int64_t rows, const float scale,
@@ -151,13 +245,13 @@ static bool fwht_launch(ggml_backend_cuda_context & ctx, const T * src_d, float 
         FWHT_CASE(64)
         FWHT_CASE(128)
         FWHT_CASE(256)
-        FWHT_CASE(512)
-        FWHT_CASE(1024)
-        FWHT_CASE(2048)
-#undef FWHT_CASE
-
-    // Beyond 2048 the register path spills, so these run the shared-memory kernel: one row per
-    // block, N floats of shared (16 KiB at 4096, 32 KiB at 8192 -- both inside the 48 KiB default).
+        default:
+            break;
+    }
+    // From 512 up, one block of FWHT_BLOCK_THREADS per row (fwht_cuda_block); the warp kernel
+    // serialised the whole transform on one warp and the shared-memory kernel synchronised every
+    // stage, and both were the largest single kernel of a decode step on the folded models.
+    // GGML_CUDA_FWHT_LEGACY=1 restores the previous kernels for A/B.
 #define FWHT_SMEM_CASE(NN) \
         case NN: { \
             const dim3 g((unsigned) rows, 1, 1), b(FWHT_SMEM_THREADS, 1, 1); \
@@ -169,9 +263,38 @@ static bool fwht_launch(ggml_backend_cuda_context & ctx, const T * src_d, float 
             } \
             return true; \
         }
-        FWHT_SMEM_CASE(4096)
-        FWHT_SMEM_CASE(8192)
+#define FWHT_BLOCK_CASE(NN) \
+        case NN: { \
+            const dim3 g((unsigned) rows, 1, 1), b(FWHT_BLOCK_THREADS, 1, 1); \
+            const ggml_cuda_kernel_launch_params lp = ggml_cuda_kernel_launch_params(g, b, 0, stream); \
+            if (signs) { \
+                ggml_cuda_kernel_launch(fwht_cuda_block<NN, FWHT_BLOCK_THREADS, T, true>,  lp, src_d, dst_d, rows, scale, signs, n_blk); \
+            } else { \
+                ggml_cuda_kernel_launch(fwht_cuda_block<NN, FWHT_BLOCK_THREADS, T, false>, lp, src_d, dst_d, rows, scale, nullptr, 1); \
+            } \
+            return true; \
+        }
+    static const bool legacy = getenv("GGML_CUDA_FWHT_LEGACY") != nullptr;
+    if (legacy) {
+        switch (n) {
+            FWHT_CASE(512)
+            FWHT_CASE(1024)
+            FWHT_CASE(2048)
+            FWHT_SMEM_CASE(4096)
+            FWHT_SMEM_CASE(8192)
+            default:
+                return false;
+        }
+    }
+    switch (n) {
+        FWHT_BLOCK_CASE(512)
+        FWHT_BLOCK_CASE(1024)
+        FWHT_BLOCK_CASE(2048)
+        FWHT_BLOCK_CASE(4096)
+        FWHT_BLOCK_CASE(8192)
+#undef FWHT_CASE
 #undef FWHT_SMEM_CASE
+#undef FWHT_BLOCK_CASE
         default:
             return false;
     }


### PR DESCRIPTION
## What

One 256-thread block per row for the Hadamard transform at widths 512 and above, replacing the warp-per-row kernel (512 to 2048) and the shared-memory kernel (4096, 8192). Stages below the warp width use shuffles, the three stages up to the block width go through shared memory, the stages above it stay in registers. Same butterfly and the same sign convention as both old kernels, so results are unchanged. Widths 64 to 256 keep the warp kernel. `GGML_CUDA_FWHT_LEGACY=1` restores the previous kernels for A/B.

## Why

An `nsys` kernel summary of a 64-token decode on an H100 PCIe put the transform first among all kernels on the folded bands, ahead of the weight mat-vecs:

| | share of GPU time | calls | per call |
|---|---|---|---|
| block 4096, shared-memory kernel | 25.8% | 8,385 | 13.8 us |
| block 2048, warp kernel | 22.5% | 7,625 | 7.7 us |

At one row the warp kernel holds N/32 floats per lane and runs all log2(N) stages on a single warp while the rest of the GPU idles; the shared-memory kernel synchronises twice per stage for all twelve stages. This is the same latency structure the Metal side had before the threadgroup-FWHT change.

## Verification (H100 PCIe, CUDA 12.8, base `8c0170d19`, separate worktrees, `-p 512 -n 128 -r 3`, two interleaved passes)

- `test-backend-ops test -b CUDA0 -o MUL_MAT_HADAMARD`: exit 0, 27/27 passed.
- Greedy output byte-identical to base on both models tested (48 tokens each).
- Same kernel summary after the change: transform 25.8% -> 14.0% of GPU time, 13.8 -> 6.8 us per row.

| band | tg128 base | tg128 this PR | tg128 with `GGML_CUDA_FWHT_LEGACY=1` | pp512 base | pp512 this PR |
|---|---|---|---|---|---|
| 9B, block 4096 | 165.9 / 167.6 | 194.6 / 194.9 (+16.7%) | 170.7 / 166.3 | 6,093 / 6,078 | 6,313 / 6,323 (+3.7%) |
| 2B, block 2048 | 355.0 / 372.1 | 391.7 / 415.2 (+11.3%) | 354.4 / 352.1 | 16,288 / 18,420 | 16,673 / 19,102 |

The legacy-env column is the same binary with the old kernels, and it lands back on the base numbers, so the delta is the kernel and not the build. Prefill spread on this card is wide (pp512 error bars are 900 to 4,700), so read the prefill column as "not worse".
