### PR TITLE
cuda: keep the PTX L2 prefetch hints off HIP and MUSA

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1000,7 +1000,7 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
                         const int hint = linear % hints_per_row;
                         const char * next = reinterpret_cast<const char *>(reinterpret_cast<const block_q1_0 *>(x) +
                             offset_x + row*stride_row_x + kb0_next) + hint*hint_stride;
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
                         asm volatile("prefetch.global.L2 [%0];" :: "l"(__cvta_generic_to_global(next)));
 #endif
                     }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -681,7 +681,7 @@ static __global__ void mul_mat_vec_q(
             if (kbx_prefetch < blocks_per_row_x && tid % (qi/vdr) == 0) {
 #pragma unroll
                 for (int i = 0; i < rows_per_cuda_block; ++i) {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
                     const block_t * prefetch_ptr = (const block_t *) vx +
                         kbx_offset + i*stride_row_x + kbx_prefetch;
                     asm volatile("prefetch.global.L2 [%0];" :: "l"(__cvta_generic_to_global(prefetch_ptr)));


### PR DESCRIPTION
## What

Two guard changes, no other code:

```
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
```

around the two PTX L2 prefetch hints added in #135: the Q1_0 J128 tile hint in `mmq.cuh` and the decode weight prefetch in `mmvq.cu`.

## Why

hipcc defines `__CUDA_ARCH__` for device code too, so the HIP builds try to compile `prefetch.global.L2` inline PTX and the CUDA-only `__cvta_generic_to_global`. Both ROCm jobs of the release workflow fail on it (run 34291069282):

```
ggml/src/ggml-cuda/mmq.cuh:1004:72: error: use of undeclared identifier '__cvta_generic_to_global'
ggml/src/ggml-cuda/mmq.cuh:1004:68: error: invalid input constraint 'l' in asm
```

For HIP and MUSA this restores the pre-#135 code at those two spots; CUDA is unchanged.

## Verification

- L40S (sm_89, CUDA 12.8): clean build, `test-backend-ops test -b CUDA0 -o MUL_MAT` 1283/1283.
- HIP itself is not testable here; the release workflow's ROCm jobs are the check.
